### PR TITLE
Fixed types

### DIFF
--- a/gobcore/events/import_message.py
+++ b/gobcore/events/import_message.py
@@ -53,10 +53,10 @@ class MessageMetaData():
         return {
             "source": self.source,
             "timestamp": self.timestamp,
-            "entity_id": self.id_column,
+            "id_column": self.id_column,
             "entity": self.entity,
             "version": self.version,
-            "gob_model": self.model
+            "model": self.model
         }
 
 

--- a/gobcore/typesystem/__init__.py
+++ b/gobcore/typesystem/__init__.py
@@ -31,7 +31,7 @@ GEO_TYPES = [
 
 # Convert GOB_TYPES to a dictionary indexed by the name of the type, prefixed by GOB.
 _gob_types = {f'GOB.{gob_type.__name__}': gob_type for gob_type in GOB_TYPES}
-_gob_geotypes = {f'GOB.GEO.{gob_type.__name__}': gob_type for gob_type in GEO_TYPES}
+_gob_geotypes = {f'GOB.Geo.{gob_type.__name__}': gob_type for gob_type in GEO_TYPES}
 _gob_types_dict = {**_gob_types, **_gob_geotypes}
 
 

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -25,7 +25,7 @@ from pandas import pandas
 
 class GOBType():
     is_pk = False
-    is_composite = True
+    is_composite = False
     name = "type"
     sql_type = sqlalchemy.Column
 


### PR DESCRIPTION
The last fix did unfortunately not solve the complete import-to-upload problem.
This PR proposes to update the naming of the import message to be consistent with the naming of the attributes that are used internally in the import message.
The GOB.GEO has been renamed to GOB.Geo to be consistent with the naming in the import client
Default a GOB Type is not composite