### PR TITLE
Add JSON Encoder for GOB Types

### DIFF
--- a/gobcore/message_broker/async_message_broker.py
+++ b/gobcore/message_broker/async_message_broker.py
@@ -14,6 +14,8 @@ import threading
 
 import pika
 
+from gobcore.typesystem.json import GobTypeJSONEncoder
+
 
 def progress(*args):
     """Utility function to facilitate debugging
@@ -203,7 +205,7 @@ class AsyncConnection(object):
             raise Exception("Connection with message broker not available")
 
         # Convert the message to json
-        json_msg = json.dumps(msg)
+        json_msg = json.dumps(msg, cls=GobTypeJSONEncoder)
 
         # Publish the message as a persistent message on the queue
         self._channel.basic_publish(

--- a/gobcore/typesystem/json.py
+++ b/gobcore/typesystem/json.py
@@ -1,0 +1,22 @@
+import json
+
+from gobcore.typesystem.gob_types import GOBType
+
+
+class GobTypeJSONEncoder(json.JSONEncoder):
+    """Extension of the json.JSONEncoder to help with encoding GOB Types into native JSON
+
+    Use as follows:
+
+        import json
+
+        gob_type = Point.from_values(x=1, y=2)
+        json.dumps(gob_type, cls=GobTypeJSONEncoder)
+
+    GOB.Geo-types will return geojson
+    """
+
+    def default(self, obj):
+        if isinstance(obj, GOBType):
+            return json.loads(obj.json)
+        return super().default(self, obj)

--- a/tests/gobcore/typesystem/test_json.py
+++ b/tests/gobcore/typesystem/test_json.py
@@ -58,6 +58,3 @@ class TestJsonEncoding(unittest.TestCase):
             gob_type = JSON.from_value(json_string)
             to_json = json.dumps(gob_type, cls=GobTypeJSONEncoder)
             self.assertEqual(json_string, to_json)
-
-
-

--- a/tests/gobcore/typesystem/test_json.py
+++ b/tests/gobcore/typesystem/test_json.py
@@ -1,0 +1,63 @@
+import json
+import unittest
+
+from gobcore.typesystem.gob_geotypes import Point
+from gobcore.typesystem.gob_types import String, Integer, Decimal, Boolean, JSON
+from gobcore.typesystem.json import GobTypeJSONEncoder
+
+from tests.gobcore import fixtures
+
+class TestJsonEncoding(unittest.TestCase):
+
+    def test_geo_json(self):
+
+        gob_type = Point.from_values(x=1, y=2)
+        geojson = json.dumps(gob_type, cls=GobTypeJSONEncoder)
+
+        self.assertEqual('{"type": "Point", "coordinates": [1.0, 2.0]}', geojson)
+
+    def test_normal_json(self):
+
+        # non primitives should be quoted
+        gob_type = String.from_value(123)
+        to_json = json.dumps({'string': gob_type}, cls=GobTypeJSONEncoder)
+        self.assertEqual('{"string": "123"}', to_json)
+
+        # Nones should be null
+        gob_type = String.from_value(None)
+        to_json = json.dumps({'string': gob_type}, cls=GobTypeJSONEncoder)
+        self.assertEqual('{"string": null}', to_json)
+
+        # Integer should be primitive
+        gob_type = Integer.from_value(123)
+        to_json = json.dumps({'string': gob_type}, cls=GobTypeJSONEncoder)
+        self.assertEqual('{"string": 123}', to_json)
+
+        # Decimal should be primitive
+        gob_type = Decimal.from_value("123,4", decimal_separator=',')
+        to_json = json.dumps({'string': gob_type}, cls=GobTypeJSONEncoder)
+        self.assertEqual('{"string": 123.4}', to_json)
+
+        # Boolean should be primitive
+        gob_type = Boolean.from_value("N", format='YN')
+        to_json = json.dumps({'string': gob_type}, cls=GobTypeJSONEncoder)
+        self.assertEqual('{"string": false}', to_json)
+
+    test_samples = [
+        '{"coordinates": [1.0, 2.0], "type": "Point"}',
+        '{"string": "123"}',
+        '{"string": null}',
+        '{"string": 123}',
+        '{"string": 123.4}',
+        '{"string": false}',
+        f'["{fixtures.random_string()}", "{fixtures.random_bool()}", "{fixtures.random_string()}"]'
+    ]
+
+    def test_json_json(self):
+        for json_string in self.test_samples:
+            gob_type = JSON.from_value(json_string)
+            to_json = json.dumps(gob_type, cls=GobTypeJSONEncoder)
+            self.assertEqual(json_string, to_json)
+
+
+


### PR DESCRIPTION
Once values become instances of GOB Types, the json encoder needs to
know how to serialize them. A GOBTypeJSONEncoder is added to address
that, it needs to be called when calling json.dumps