### PR TITLE
Improve service definition for messagedriven_service

### DIFF
--- a/tests/gobcore/fixtures.py
+++ b/tests/gobcore/fixtures.py
@@ -16,13 +16,17 @@ def random_string(length=12, source=None):
 def get_service_fixture(handler):
     return {
         random_string(): {
+            'exchange': random_string(),
             'queue': random_string(),
+            'key': random_string(),
             'handler': handler,
-            'report_back': random_string(),
-            'report_queue': random_string()
+            'report': {
+                'exchange': random_string(),
+                'queue': random_string(),
+                'key': random_string()
+            }
         }
     }
-
 
 def random_bool():
     return random.choice([True, False])


### PR DESCRIPTION
Messagedriven service was using the same exchange for all requests. Report functionality is now optional and code has been simplified.