### PR TITLE
Add process_id to logging and messages

### DIFF
--- a/gobcore/events/import_message.py
+++ b/gobcore/events/import_message.py
@@ -20,9 +20,10 @@ class MessageMetaData():
                 self.id_column is None or \
                 self.entity is None or \
                 self.version is None or \
+                self.process_id is None or \
                 self.model is None:
             raise GOBException("Incomplete metadata, all of source, timestamp, id_column, entity, version "
-                               "and model need to be defined")
+                               "process_id and model need to be defined")
 
     @property
     def source(self):
@@ -45,6 +46,10 @@ class MessageMetaData():
         return self._header['version']
 
     @property
+    def process_id(self):
+        return self._header['process_id']
+
+    @property
     def model(self):
         return self._header['model']
 
@@ -56,6 +61,7 @@ class MessageMetaData():
             "id_column": self.id_column,
             "entity": self.entity,
             "version": self.version,
+            "process_id": self.process_id,
             "model": self.model
         }
 

--- a/gobcore/log.py
+++ b/gobcore/log.py
@@ -35,6 +35,10 @@ class RequestsHandler(logging.Handler):
             "formatted_msg": self.format(record)
         }
 
+        log_msg['process_id'] = getattr(record, 'process_id', None)
+        log_msg['source'] = getattr(record, 'source', None)
+        log_msg['entity'] = getattr(record, 'entity', None)
+
         publish(LOG_QUEUE, record.levelname, log_msg)
 
 

--- a/tests/gobcore/events/test_message.py
+++ b/tests/gobcore/events/test_message.py
@@ -1,0 +1,41 @@
+import unittest
+
+from gobcore.events.import_message import ImportMessage, MessageMetaData
+from gobcore.exceptions import GOBException
+
+from tests.gobcore import fixtures
+
+
+class TestEvents(unittest.TestCase):
+
+    def test_MessageMetaData(self):
+        # Test creation of MessageMetaData
+        metadata = fixtures.get_metadata_fixture()
+
+        header = metadata.as_header
+        keys = ['source', 'timestamp', 'id_column', 'entity', 'version', 'process_id', 'model']
+        for key in keys:
+            self.assertIn(key, header)
+
+        # Test failure if not all keys are present
+        header['source'] = None
+
+        with self.assertRaises(GOBException):
+            MessageMetaData(**header)
+
+        header.pop('source')
+        with self.assertRaises(KeyError):
+            MessageMetaData(**header)
+
+
+    def test_ImportMessage(self):
+        metadata = fixtures.get_metadata_fixture()
+        header = metadata.as_header
+        summary = 'summary'
+        contents = 'contents'
+        msg = ImportMessage.create_import_message(header, summary, contents)
+        import_message = ImportMessage(msg)
+
+        self.assertIsInstance(import_message.metadata, MessageMetaData)
+        self.assertEqual(import_message.summary, 'summary')
+        self.assertEqual(import_message.contents, 'contents')

--- a/tests/gobcore/fixtures.py
+++ b/tests/gobcore/fixtures.py
@@ -52,4 +52,5 @@ def get_metadata_fixture():
     header = {key: random_string() for key in ["source", "timestamp", "version", "model"]}
     header['entity'] = 'meetbouten'
     header['id_column'] = 'meetboutid'
+    header['process_id'] = f"{header['timestamp']}.{header['source']}.{header['entity']}"
     return MessageMetaData(**header)


### PR DESCRIPTION
Messages on the broker are now required to have an process_id to be able to monitor the process during the steps taken in GOB. This process_id is also added to the logging.