### PR TITLE
Add JSON data field to logging

### DIFF
--- a/gobcore/log.py
+++ b/gobcore/log.py
@@ -38,6 +38,7 @@ class RequestsHandler(logging.Handler):
         log_msg['process_id'] = getattr(record, 'process_id', None)
         log_msg['source'] = getattr(record, 'source', None)
         log_msg['entity'] = getattr(record, 'entity', None)
+        log_msg['data'] = getattr(record, 'data', None)
 
         publish(LOG_QUEUE, record.levelname, log_msg)
 

--- a/gobcore/log.py
+++ b/gobcore/log.py
@@ -28,7 +28,7 @@ class RequestsHandler(logging.Handler):
         :return: None
         """
         log_msg = {
-            "timestamp": datetime.datetime.now().replace(microsecond=0).isoformat(),
+            "timestamp": datetime.datetime.now().isoformat(),
             "level": record.levelname,
             "name": record.name,
             "msg": record.msg,


### PR DESCRIPTION
This fixes the missing data field in a log record. This can be used for extra json data used in logging