### PR TITLE
Add entity views

### DIFF
--- a/gobcore/model/metadata.py
+++ b/gobcore/model/metadata.py
@@ -33,6 +33,13 @@ FIXED_COLUMNS = {
     "_id": "GOB.String"         # Provide for a generic (independent from Stelselpedia) id field for every entity
 }
 
+PRIVATE_META_FIELDS = {
+        field_name: {
+            "type": field_type,
+            "description": ""
+        } for field_name, field_type in METADATA_COLUMNS["private"].items()
+    }
+
 PUBLIC_META_FIELDS = {
         field_name: {
             "type": field_type,

--- a/gobcore/views/__init__.py
+++ b/gobcore/views/__init__.py
@@ -1,0 +1,19 @@
+import os
+import json
+
+
+class GOBViews():
+    def __init__(self):
+        path = os.path.join(os.path.dirname(__file__), 'gobviews.json')
+        with open(path) as file:
+            data = json.load(file)
+        self._data = data
+
+    def get_catalogs(self):
+        return list(self._data.keys())
+
+    def get_entities(self, catalog_name):
+        return list(self._data[catalog_name].keys())
+
+    def get_views(self, catalog_name, entity_name):
+        return self._data[catalog_name][entity_name]

--- a/gobcore/views/gobviews.json
+++ b/gobcore/views/gobviews.json
@@ -1,0 +1,25 @@
+{
+  "meetbouten": {
+    "meetbouten": {
+      "enhanced": {
+        "version": "0.1",
+        "query": [
+"    SELECT meetbouten.*",
+"    ,       eerste_metingen.datum                                          AS datum",
+"    ,       meest_recente_metingen.hoogte_tov_nap",
+"    ,       meest_recente_metingen.zakkingssnelheid",
+"    ,       meest_recente_metingen.zakking_cumulatief",
+"    FROM              meetbouten",
+"    LEFT JOIN (",
+"            SELECT DISTINCT ON (hoort_bij_meetbout_id) * from metingen",
+"            ORDER BY hoort_bij_meetbout_id, datum DESC",
+"    ) AS meest_recente_metingen          ON meetbouten._id = meest_recente_metingen.hoort_bij_meetbout_id",
+"    LEFT JOIN (",
+"            SELECT DISTINCT ON (hoort_bij_meetbout_id) * from metingen",
+"            ORDER BY hoort_bij_meetbout_id, datum ASC",
+"    ) AS eerste_metingen                 ON meetbouten._id = eerste_metingen.hoort_bij_meetbout_id"
+        ]
+      }
+    }
+  }
+}

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest
 
 echo "Running coverage tests"
-pytest --cov=gobcore --cov-report html --cov-fail-under=70
+pytest --cov=gobcore --cov-report html --cov-fail-under=78

--- a/tests/gobcore/typesystem/test_sql_types.py
+++ b/tests/gobcore/typesystem/test_sql_types.py
@@ -1,0 +1,17 @@
+import sqlalchemy
+import unittest
+
+from gobcore.exceptions import GOBException
+from gobcore.typesystem import get_gob_type_from_sql_type, _gob_postgres_sql_types_list
+
+
+class TestSQLTypes(unittest.TestCase):
+
+    def test_sql_types(self):
+        for mapping in _gob_postgres_sql_types_list:
+            gob_type = get_gob_type_from_sql_type(mapping['sql_type'])
+            self.assertEqual(gob_type, mapping['gob_type'])
+
+    def test_unknown_sql_type(self):
+        with self.assertRaises(GOBException):
+            get_gob_type_from_sql_type(sqlalchemy.types.ARRAY)

--- a/tests/gobcore/views/test_gobviews.py
+++ b/tests/gobcore/views/test_gobviews.py
@@ -1,0 +1,33 @@
+import unittest
+
+from gobcore.views import GOBViews
+
+
+class TestEvents(unittest.TestCase):
+
+    def setUp(self):
+        self.views = GOBViews()
+
+    def test_initialize_gob_views(self):
+        # Assert internal data has been set
+        self.assertIsNotNone(self.views._data)
+
+    def test_get_view(self):
+        # Test catalog meetbouten exists and returns the correct value
+        catalogs = self.views.get_catalogs()
+        self.assertIn('meetbouten', catalogs)
+
+        # Test entity meetbouten exists in catalog meetbouten and returns the correct value
+        entities = self.views.get_entities('meetbouten')
+        self.assertIn('meetbouten', entities)
+
+        # Test view enhanced exists in entity meetbouten and returns the correct value
+        views = self.views.get_views('meetbouten', 'meetbouten')
+        self.assertIn('enhanced', views)
+
+    def test_queries(self):
+        # Test that each view has a query defined
+        for catalog in self.views.get_catalogs():
+            for entity in self.views.get_entities(catalog):
+                for view_name, view in self.views.get_views(catalog, entity).items():
+                    self.assertIn('query', view)


### PR DESCRIPTION
Added views to gobcore to be used in the API.

Added a mapping to match SQLTypes to GOBTypes. For now a specific postgres mapping has been made and an issue has been raised to find a better solution. Tests were added. Private meta fields were added to be able to remove those from views in the API.