### PR TITLE
Updated views and model

### DIFF
--- a/gobcore/model/__init__.py
+++ b/gobcore/model/__init__.py
@@ -24,7 +24,7 @@ class GOBModel():
                 # For references add the _text and _id fields with type GOB.String
                 fields[f'{field_name}_text'] = attributes
                 fields[f'{field_name}_id'] = {
-                    'type': "GOB.String",
+                    'type': attributes['type'],
                     'description': f"Reference ID to {ref}"
                 }
             else:

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -63,14 +63,6 @@
         "description": "Het stadsdeel waarbinnen de meetbout ligt",
         "ref": "buurt"
       },
-      "xcoordinaat": {
-        "type": "GOB.Decimal",
-        "description": "X-coördinaat van de locatie van de meetbout"
-      },
-      "ycoordinaat": {
-        "type": "GOB.Decimal",
-        "description": "Y-coördinaat van de locatie van de meetbout"
-      },
       "geometrie": {
         "type": "GOB.Geo.Point",
         "srid": "RD",
@@ -134,8 +126,7 @@
       },
       "is_gemeten_door": {
         "type": "GOB.String",
-        "description": "ID Van de onderneming die de meting heeft uitgevoerd",
-        "ref": "onderneming"
+        "description": "ID Van de onderneming die de meting heeft uitgevoerd"
       },
       "hoeveelste_meting": {
         "type": "GOB.Integer",
@@ -163,6 +154,14 @@
       "locatie": {
         "type": "GOB.String",
         "description": "Beschrijving van de locatie van het referentiepunt bijv 'nabij noordoostelijke gevelhoek'."
+      },
+      "hoogte_tov_nap": {
+        "type": "GOB.Decimal",
+        "description": "Hoog­te van het re­fe­ren­tie­punt t.o.v. NAP"
+      },
+      "datum": {
+        "type": "GOB.Date",
+        "description": "Da­tum van plaat­sing van het re­fe­ren­tie­punt."
       },
       "status_id": {
         "type": "GOB.Character",
@@ -211,18 +210,15 @@
         "description": "Het stadsdeel waarbinnen het referentiepunt ligt",
         "ref": "buurt"
       },
-      "xcoordinaat": {
-        "type": "GOB.Decimal",
-        "description": "X-coördinaat van de locatie van het referentiepunt"
-      },
-      "ycoordinaat": {
-        "type": "GOB.Decimal",
-        "description": "Y-coördinaat van de locatie van het referentiepunt"
-      },
       "geometrie": {
         "type": "GOB.Geo.Point",
         "srid": "RD",
         "description": "Geometrische ligging van de meetbout"
+      },
+      "is_nap_peilmerk": {
+        "type": "GOB.String",
+        "description": "Het NAP-peil­merk dat het re­fe­ren­tie­punt kan zijn.",
+        "ref": "peilmerk"
       },
       "publiceerbaar": {
         "type": "GOB.Boolean",

--- a/gobcore/typesystem/__init__.py
+++ b/gobcore/typesystem/__init__.py
@@ -44,12 +44,14 @@ _gob_sql_types_list = [{'gob_type': gob_type, 'sql_type': gob_type.sql_type} for
 # Postgres specific mapping for sql types to GOBTypes
 _gob_postgres_sql_types_list = [
     {'sql_type': sqlalchemy.types.VARCHAR, 'gob_type': GOB.String},
+    {'sql_type': sqlalchemy.types.TEXT, 'gob_type': GOB.String},
     {'sql_type': sqlalchemy.types.CHAR, 'gob_type': GOB.Character},
     {'sql_type': sqlalchemy.types.INTEGER, 'gob_type': GOB.Integer},
     {'sql_type': sqlalchemy.types.NUMERIC, 'gob_type': GOB.Decimal},
     {'sql_type': sqlalchemy.types.BOOLEAN, 'gob_type': GOB.Boolean},
     {'sql_type': sqlalchemy.types.DATE, 'gob_type': GOB.Date},
     {'sql_type': sqlalchemy.dialects.postgresql.base.TIMESTAMP, 'gob_type': GOB.DateTime},
+    {'sql_type': sqlalchemy.dialects.postgresql.JSON, 'gob_type': GOB.JSON},
     {'sql_type': sqlalchemy.types.JSON, 'gob_type': GOB.JSON},
     {'sql_type': geoalchemy2.types.Geometry, 'gob_type': GEO.Point},
 ]

--- a/gobcore/views/gobviews.json
+++ b/gobcore/views/gobviews.json
@@ -20,6 +20,25 @@
 "    ) AS eerste_metingen                 ON meetbouten._id = eerste_metingen.hoort_bij_meetbout_id"
         ]
       }
+    },
+    "metingen": {
+      "enhanced": {
+        "version": "0.1",
+        "query": [
+"    SELECT metingen.*",
+"    ,       refereert_aan_id->>0                                 AS refp1_nr",
+"    ,       refereert_aan_id->>1                                 AS refp2_nr",
+"    ,       refereert_aan_id->>2                                 AS refp3_nr",
+"    ,       CASE WHEN wijze_van_inwinnen_id = '1' THEN 'W'",
+"                 WHEN wijze_van_inwinnen_id = '2' THEN 'T'",
+"                 WHEN wijze_van_inwinnen_id = '3' THEN 'G' END   AS wvi",
+"    ,       meetbouten.ligt_in_stadseel_text",
+"    FROM  metingen",
+"    LEFT JOIN (",
+"            SELECT _id, ligt_in_stadseel_text from meetbouten",
+"    ) AS meetbouten ON metingen.hoort_bij_meetbout_id = meetbouten._id"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Views and model were updated to match the latest specifications needed for export. Reference id field now use the gobtype of the parent. This was needed to accept JSON reference fields. Two extra sql types were added to match to gobtypes.