### PR TITLE
Persistent log connection

### DIFF
--- a/gobcore/log.py
+++ b/gobcore/log.py
@@ -10,13 +10,19 @@ Todo:
 """
 import logging
 import datetime
+import atexit
 
-from gobcore.message_broker.config import LOG_QUEUE
-from gobcore.message_broker import publish
-
+from gobcore.log_publisher import LogPublisher
 
 LOGFORMAT = "%(asctime)s %(name)-12s %(levelname)-8s %(message)s"
 LOGLEVEL = logging.INFO
+
+# Instantiate a log publisher
+LOG_PUBLISHER = LogPublisher()
+# Connect to the message broker
+LOG_PUBLISHER.connect()
+# Disconnect at exit
+atexit.register(LOG_PUBLISHER.disconnect)
 
 
 class RequestsHandler(logging.Handler):
@@ -40,7 +46,7 @@ class RequestsHandler(logging.Handler):
         log_msg['entity'] = getattr(record, 'entity', None)
         log_msg['data'] = getattr(record, 'data', None)
 
-        publish(LOG_QUEUE, record.levelname, log_msg)
+        LOG_PUBLISHER.publish(record.levelname, log_msg)
 
 
 def get_logger(name):
@@ -59,7 +65,7 @@ def get_logger(name):
 
     logger.addHandler(handler)
 
-    # Temporary loggin also to stdout
+    # Temporary logging also to stdout
     stdout_handler = logging.StreamHandler()
     logger.addHandler(stdout_handler)
 

--- a/gobcore/log_publisher.py
+++ b/gobcore/log_publisher.py
@@ -1,0 +1,32 @@
+"""LogPublisher
+
+This module contains the LogPublisher class.
+
+A LogPublisher publishes log message on the message broker.
+
+"""
+from gobcore.message_broker.message_broker import Connection
+from gobcore.message_broker.config import get_queue
+
+from gobcore.message_broker.config import CONNECTION_PARAMS
+from gobcore.message_broker.config import LOG_QUEUE
+
+
+class LogPublisher():
+
+    _connection = None
+    _queue = None
+
+    def __init__(self, connection_params=CONNECTION_PARAMS, queue_name=LOG_QUEUE):
+        # Open a connection and register the log queue
+        self._connection = Connection(connection_params)
+        self._queue = get_queue(queue_name)
+
+    def publish(self, level, msg):
+        self._connection.publish(self._queue, level, msg)
+
+    def connect(self):
+        self._connection.connect()
+
+    def disconnect(self):
+        self._connection.disconnect()

--- a/gobcore/message_broker/message_broker.py
+++ b/gobcore/message_broker/message_broker.py
@@ -1,0 +1,79 @@
+"""Synchronous message broker
+
+Simple synchronous message broker.
+
+Only publication is supported
+
+"""
+import json
+import pika
+
+from gobcore.typesystem.json import GobTypeJSONEncoder
+
+
+class Connection(object):
+    """This is an synchronous RabbitMQ connection.
+
+    No automatic reconnection with RabbitMQ is implemented.
+
+    """
+
+    def __init__(self, connection_params):
+        """Create a new Connection
+
+        :param address: The RabbitMQ address
+        """
+
+        # The connection parameters for the RabbitMQ Message broker
+        self._connection_params = connection_params
+
+        # The Connection and Channel objects
+        self._connection = None
+        self._channel = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, *args):
+        self.disconnect()
+
+    def connect(self):
+        self._connection = pika.BlockingConnection(self._connection_params)
+        self._channel = self._connection.channel()
+
+    def publish(self, queue, key, msg):
+        # Check whether a connection has been established
+        if self._channel is None:
+            raise Exception("Connection with message broker not available")
+
+        # Convert the message to json
+        json_msg = json.dumps(msg, cls=GobTypeJSONEncoder, allow_nan=False)
+
+        self._channel.basic_publish(
+            exchange=queue["exchange"],
+            routing_key=key,
+            properties=pika.BasicProperties(
+                delivery_mode=2  # Make messages persistent
+            ),
+            body=json_msg
+        )
+
+    def disconnect(self):
+        """Disconnect from RabbitMQ
+
+        Close any open channels
+        Close the connection
+        Stop any running eventloop
+
+        :return: None
+        """
+        # Close any open channel
+        if self._channel is not None and self._channel.is_open:
+            self._channel.close()
+        self._channel = None
+
+        # Close any open connection
+        if self._connection is not None:
+            self._connection.close()
+        self._connection = None

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest
 
 echo "Running coverage tests"
-pytest --cov=gobcore --cov-report html --cov-fail-under=79
+pytest --cov=gobcore --cov-report html --cov-fail-under=80

--- a/tests/gobcore/message_broker/test_sync_message_broker.py
+++ b/tests/gobcore/message_broker/test_sync_message_broker.py
@@ -1,0 +1,119 @@
+import json
+import pika
+import pytest
+
+from mock import patch
+
+from gobcore.message_broker.message_broker import Connection
+
+
+class MockChannel:
+
+    is_open = None
+
+    def __init__(self):
+        self.is_open = True
+
+    def close(self):
+        self.is_open = False
+
+    def basic_publish(self,
+                      exchange,
+                      routing_key,
+                      properties,
+                      body):
+        global published_message
+        published_message = body
+
+
+class MockConnection:
+
+    def __init__(self):
+        pass
+
+    def close(self):
+        pass
+
+    def channel(self):
+        return MockChannel()
+
+
+class MockPika:
+
+    def BlockingConnection(self, params):
+        self._params = params
+        return MockConnection()
+
+
+published_message = None
+connection_params = {'host': "host", 'credentials': {'username': "username", 'password': "password"}}
+
+
+def mock_connection(monkeypatch):
+    _pika = MockPika()
+    monkeypatch.setattr(pika, 'BlockingConnection', _pika.BlockingConnection)
+
+    global published_message
+    published_message = None
+
+
+def test_connection_constructor():
+    # Test if a connection can be initialized
+    connection = Connection(connection_params)
+    assert(connection is not None)
+    assert(connection._connection_params == connection_params)
+
+
+def test_disconnect():
+    # Test if a disconnect can be called without an earlier connect
+    connection = Connection('')
+    assert(connection.disconnect() is None)
+
+
+def test_idempotent_disconnect():
+    # Test disconnect repeated execution
+    connection = Connection('')
+    assert(connection.disconnect() is None)
+    assert(connection.disconnect() is None)
+
+
+def test_connect_context_manager(monkeypatch):
+    # Test if context manager calls disconnect on exit with statement
+    mock_connection(monkeypatch)
+
+    org_connection = None
+    with patch.object(Connection, 'disconnect') as mocked_disconnect:
+        with Connection(connection_params) as connection:
+            org_connection = connection  # save to call the real disconnect afterwards
+            pass
+        assert(mocked_disconnect.called)
+    org_connection.disconnect()    # Call the real disconnect
+
+
+def test_publish(monkeypatch):
+    # Test publish message
+    mock_connection(monkeypatch)
+
+    connection = Connection(connection_params)
+    connection.connect()
+    queue = {
+        "exchange": "exchange",
+        "name": "name",
+        "key": "key"
+    }
+    connection.publish(queue, "key", "message")
+    assert(published_message == json.dumps("message"))
+    connection.disconnect()
+
+
+def test_publish_failure(monkeypatch):
+    # Test publish failure
+    mock_connection(monkeypatch)
+
+    connection = Connection(connection_params)
+    queue = {
+        "name": "name",
+        "key": "key"
+    }
+    with pytest.raises(Exception):
+        connection.publish(queue, "key", "message")

--- a/tests/test_log_publisher.py
+++ b/tests/test_log_publisher.py
@@ -1,0 +1,33 @@
+import mock
+import unittest
+
+from gobcore.log_publisher import LogPublisher
+
+
+class TestLogPublisher(unittest.TestCase):
+
+    def testConstructor(self):
+        # Test if a log publisher can be initialized
+        publisher = LogPublisher(None)
+        assert(publisher is not None)
+
+
+    @mock.patch('gobcore.message_broker.message_broker.Connection.publish')
+    def testPublish(self, patched_publish):
+        publisher = LogPublisher(None)
+        publisher.publish("Level", "Message")
+        assert(patched_publish.called)
+
+
+    @mock.patch('gobcore.message_broker.message_broker.Connection.connect')
+    def testConnect(self, patched_connect):
+        publisher = LogPublisher(None)
+        publisher.connect()
+        assert(patched_connect.called)
+
+
+    @mock.patch('gobcore.message_broker.message_broker.Connection.disconnect')
+    def testDisconnect(self, patched_disconnnect):
+        publisher = LogPublisher(None)
+        publisher.disconnect()
+        assert(patched_disconnnect.called)


### PR DESCRIPTION
Logging used to establish and close a connection with the
message broker on every log message.

Now, a connection is set up once.
This connection is used for all log messages
At exit the connection is closed