### PR TITLE
Log messages with auto disconnect from the message broker

### DIFF
--- a/gobcore/log.py
+++ b/gobcore/log.py
@@ -10,7 +10,6 @@ Todo:
 """
 import logging
 import datetime
-import atexit
 
 from gobcore.log_publisher import LogPublisher
 
@@ -45,8 +44,6 @@ class RequestsHandler(logging.Handler):
         if LOG_PUBLISHER is None:
             # Instantiate a log publisher
             LOG_PUBLISHER = LogPublisher()
-            # Disconnect at exit
-            atexit.register(LOG_PUBLISHER.disconnect)
 
         LOG_PUBLISHER.publish(record.levelname, log_msg)
 

--- a/gobcore/log_publisher.py
+++ b/gobcore/log_publisher.py
@@ -5,6 +5,9 @@ This module contains the LogPublisher class.
 A LogPublisher publishes log message on the message broker.
 
 """
+import threading
+import time
+
 from gobcore.message_broker.message_broker import Connection
 from gobcore.message_broker.config import get_queue
 
@@ -15,20 +18,47 @@ from gobcore.message_broker.config import LOG_QUEUE
 class LogPublisher():
 
     _connection = None
-    _queue = None
+    _connection_lock = threading.Lock()
+    _auto_disconnect_thread = None
+    _auto_disconnect_timeout = 0
 
     def __init__(self, connection_params=CONNECTION_PARAMS, queue_name=LOG_QUEUE):
-        # Open a connection and register the log queue
-        self._connection = Connection(connection_params)
+        # Register the connection params and log queue
+        self._connection_params = connection_params
         self._queue = get_queue(queue_name)
 
     def publish(self, level, msg):
-        if not self._connection.is_alive():
-            self.connect()
-        self._connection.publish(self._queue, level, msg)
+        # Acquire a lock for the connection
+        with self._connection_lock:
+            # Connect to the message broker, auto disconnect after timeout seconds
+            self._auto_connect(timeout=2)
+            # Publish the message
+            self._connection.publish(self._queue, level, msg)
 
-    def connect(self):
-        self._connection.connect()
+    def _auto_connect(self, timeout):
+        self._auto_disconnect_timeout = timeout
+        if self._connection is None:
+            # Start a connection if no connection is active
+            self._connection = Connection(self._connection_params)
+            self._connection.connect()
+            # Start auto disconnect thread
+            if self._auto_disconnect_thread is not None:
+                # Join any previously ended threads
+                self._auto_disconnect_thread.join()
+            self._auto_disconnect_thread = threading.Thread(target=self._auto_disconnect)
+            self._auto_disconnect_thread.start()
 
-    def disconnect(self):
-        self._connection.disconnect()
+    def _disconnect(self):
+        if self._connection is not None:
+            self._connection.disconnect()
+            self._connection = None
+
+    def _auto_disconnect(self):
+        while True:
+            time.sleep(1)
+            with self._connection_lock:
+                if self._auto_disconnect_timeout > 0:
+                    self._auto_disconnect_timeout -= 1
+                else:
+                    self._disconnect()
+                    break

--- a/tests/test_log_publisher.py
+++ b/tests/test_log_publisher.py
@@ -12,8 +12,9 @@ class TestLogPublisher(unittest.TestCase):
         assert(publisher is not None)
 
     @mock.patch('gobcore.log_publisher.LogPublisher._auto_disconnect')
+    @mock.patch('gobcore.message_broker.message_broker.Connection.connect')
     @mock.patch('gobcore.message_broker.message_broker.Connection.publish')
-    def testPublish(self, patched_publish, patched_auto_disconnect):
+    def testPublish(self, patched_publish, patched_connect, patched_auto_disconnect):
         publisher = LogPublisher(None)
         publisher.publish("Level", "Message")
         assert(patched_publish.called)

--- a/tests/test_log_publisher.py
+++ b/tests/test_log_publisher.py
@@ -11,27 +11,19 @@ class TestLogPublisher(unittest.TestCase):
         publisher = LogPublisher(None)
         assert(publisher is not None)
 
-
-    @mock.patch('gobcore.message_broker.message_broker.Connection.is_alive', return_value=True)
+    @mock.patch('gobcore.log_publisher.LogPublisher._auto_disconnect')
     @mock.patch('gobcore.message_broker.message_broker.Connection.publish')
-    def testPublish(self, patched_publish, pathed_is_alive):
+    def testPublish(self, patched_publish, patched_auto_disconnect):
         publisher = LogPublisher(None)
         publisher.publish("Level", "Message")
         assert(patched_publish.called)
-        assert(pathed_is_alive.called)
 
 
-    @mock.patch('gobcore.message_broker.message_broker.Connection.is_alive', return_value=True)
+    @mock.patch('gobcore.log_publisher.LogPublisher._auto_disconnect')
     @mock.patch('gobcore.message_broker.message_broker.Connection.connect')
-    def testConnect(self, patched_connect, pathed_is_alive):
+    @mock.patch('gobcore.message_broker.message_broker.Connection.publish')
+    def testAutoConnect(self, patched_publish, patched_connect, patched_auto_disconnect):
         publisher = LogPublisher(None)
-        publisher.connect()
+        publisher.publish("Level", "Message")
         assert(patched_connect.called)
-
-
-    @mock.patch('gobcore.message_broker.message_broker.Connection.is_alive', return_value=True)
-    @mock.patch('gobcore.message_broker.message_broker.Connection.disconnect')
-    def testDisconnect(self, patched_disconnnect, pathed_is_alive):
-        publisher = LogPublisher(None)
-        publisher.disconnect()
-        assert(patched_disconnnect.called)
+        assert(patched_auto_disconnect.called)


### PR DESCRIPTION
A connection is setup with the message broker when a message
is logged. The connection is left open for a few seconds to
wait for any more messages to log.

When the connection is left idle it is automatically closed.

On any new log message it is automatically reopened.