### PR TITLE
Renamed identificatie in model

### DIFF
--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -1,9 +1,9 @@
 {
   "meetbouten": {
     "version": "0.1",
-    "entity_id": "meetboutidentificatie",
+    "entity_id": "identificatie",
     "attributes": {
-      "meetboutidentificatie": {
+      "identificatie": {
         "type": "GOB.String",
         "description": "Unieke identificatie van de meetbout"
       },
@@ -82,9 +82,9 @@
   },
   "metingen": {
     "version": "0.1",
-    "entity_id": "metingidentificatie",
+    "entity_id": "identificatie",
     "attributes": {
-      "metingidentificatie": {
+      "identificatie": {
         "type": "GOB.String",
         "description": "Unieke identificatie van de meting"
       },
@@ -151,9 +151,9 @@
   },
   "referentiepunten": {
     "version": "0.1",
-    "entity_id": "referentiepuntidentificatie",
+    "entity_id": "identificatie",
     "attributes": {
-      "referentiepuntidentificatie": {
+      "identificatie": {
         "type": "GOB.String",
         "description": "Unieke identificatie van de meting"
       },
@@ -245,9 +245,9 @@
   },
   "rollagen": {
     "version": "0.1",
-    "entity_id": "rollaagidentificatie",
+    "entity_id": "identificatie",
     "attributes": {
-      "rollaagidentificatie": {
+      "identificatie": {
         "type": "GOB.String",
         "description": "Unieke identificatie van de rollaag"
       },

--- a/gobcore/typesystem/__init__.py
+++ b/gobcore/typesystem/__init__.py
@@ -1,6 +1,6 @@
 """GOB Data types
 
-GOB data consists of entities with attributes, eg Meetbout = { meetboutidentificatie, locatie, ... }
+GOB data consists of entities with attributes, eg Meetbout = { identificatie, locatie, ... }
 The possible types for each attribute are defined in this module.
 The definition and characteristics of each type is in the gob_types module
 

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -323,7 +323,7 @@ class Date(String):
 class DateTime(Date):
     name = "DateTime"
     sql_type = sqlalchemy.DateTime
-    internal_format = "%Y-%m-%d %H:%M:%S.%f"
+    internal_format = "%Y-%m-%dT%H:%M:%S.%f"
 
     def __init__(self, value):
         super().__init__(value)
@@ -333,6 +333,8 @@ class DateTime(Date):
         input_format = kwargs['format'] if 'format' in kwargs else cls.internal_format
 
         if value is not None:
+            # Convert to isoformat if value is a datetime object
+            value = value.isoformat() if isinstance(value, datetime.datetime) else value
             try:
                 value = datetime.datetime.strptime(str(value), input_format).strftime(cls.internal_format)
             except ValueError as v:

--- a/gobcore/views/gobviews.json
+++ b/gobcore/views/gobviews.json
@@ -45,9 +45,9 @@
         "version": "0.1",
         "query": [
 "    SELECT *",
-"    ,       row_number() OVER (order by rollaagidentificatie) as idx",
+"    ,       row_number() OVER (order by identificatie) as idx",
 "    FROM  rollagen",
-"    ORDER BY rollaagidentificatie"
+"    ORDER BY identificatie"
         ]
       }
     }


### PR DESCRIPTION
All models now have identificatie as entity id column to match the latest update in specs. A small fix was added to use isoformat for datetime in gob type