### PR TITLE
Add GOBSources for relations between entities

### DIFF
--- a/gobcore/sources/__init__.py
+++ b/gobcore/sources/__init__.py
@@ -1,0 +1,59 @@
+import json
+import os
+
+from collections import defaultdict
+
+from gobcore.model import GOBModel
+
+
+class GOBSources():
+    def __init__(self):
+        path = os.path.join(os.path.dirname(__file__), 'gobsources.json')
+        with open(path) as file:
+            data = json.load(file)
+
+        self._data = data
+        self._model = GOBModel()
+
+        self._relations = {}
+
+        # Extract references for easy access in API
+        for source_name, source in self._data.items():
+            self._relations.update(self._extract_relations(source_name, source))
+
+    def _extract_relations(self, source_name, source):
+        relations = defaultdict(lambda: defaultdict(list))
+        for catalog_name, catalog in self._model.get_catalogs().items():
+            for collection_name, collection in catalog['collections'].items():
+                for field_name, spec in collection['references'].items():
+                    relation = {
+                        'source': source_name,
+                        'catalog': catalog_name,
+                        'collection': collection_name,
+                        'field_name': field_name
+                    }
+
+                    relation.update(
+                        self._get_field_relation(
+                            source,
+                            catalog_name,
+                            collection_name,
+                            field_name
+                        )
+                    )
+                    ref_catalog, ref_collection = spec['ref'].split(':')
+
+                    relations[ref_catalog][ref_collection].append(relation)
+        return relations
+
+    def _get_field_relation(self, source, catalog_name, collection_name, field_name):
+        try:
+            relation = source[catalog_name][collection_name][field_name]
+        except KeyError:
+            return {}
+        else:
+            return relation
+
+    def get_relations(self, catalog_name, collection_name):
+
+        return self._relations[catalog_name][collection_name]

--- a/gobcore/sources/gobsources.json
+++ b/gobcore/sources/gobsources.json
@@ -1,0 +1,73 @@
+{
+  "Grondslag": {
+    "meetbouten": {
+      "meetbouten": {
+        "ligt_in_bouwblok": {
+          "method": "geo_in",
+          "source_attribute": "geometrie",
+          "destination_attribute": "geometrie"
+        },
+        "ligt_in_buurt": {
+          "method": "geo_in",
+          "source_attribute": "geometrie",
+          "destination_attribute": "geometrie"
+        },
+        "ligt_in_stadseel": {
+          "method": "geo_in",
+          "source_attribute": "geometrie",
+          "destination_attribute": "geometrie"
+        }
+      },
+      "metingen": {
+        "hoort_bij_meetbout": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        },
+        "refereert_aan": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        }
+      },
+      "referentiepunten": {
+        "ligt_in_bouwblok": {
+          "method": "geo_in",
+          "source_attribute": "geometrie",
+          "destination_attribute": "geometrie"
+        },
+        "ligt_in_buurt": {
+          "method": "geo_in",
+          "source_attribute": "geometrie",
+          "destination_attribute": "geometrie"
+        },
+        "ligt_in_stadseel": {
+          "method": "geo_in",
+          "source_attribute": "geometrie",
+          "destination_attribute": "geometrie"
+        },
+        "is_nap_peilmerk": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        }
+      }
+    },
+    "nap": {
+      "peilmerken": {
+        "ligt_in_bouwblok": {
+          "method": "geo_in",
+          "source_attribute": "geometrie",
+          "destination_attribute": "geometrie"
+        }
+      }
+    }
+  },
+  "Basisinformatie": {
+    "meetbouten": {
+      "rollagen": {
+        "is_gemeten_van_bouwblok": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        }
+      }
+    }
+  }
+}

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -347,7 +347,7 @@ class DateTime(Date):
 
 class JSON(GOBType):
     name = "JSON"
-    sql_type = sqlalchemy.JSON
+    sql_type = sqlalchemy.dialects.postgresql.JSONB
 
     def __init__(self, value):
         if value is not None:

--- a/tests/gobcore/sources/test_sources.py
+++ b/tests/gobcore/sources/test_sources.py
@@ -1,0 +1,13 @@
+import unittest
+
+from gobcore.sources import GOBSources
+
+
+class TestSources(unittest.TestCase):
+
+    def setUp(self):
+        self.sources = GOBSources()
+
+    def test_get_relations(self):
+        # Assert we get a list of relations for a collection
+        self.assertIsInstance(self.sources.get_relations('nap', 'peilmerken'), list)


### PR DESCRIPTION
GOBSources was added to be able to build relations between entities based on the value of the source they were imported from.