### PR TITLE
Add state columns and polygon type, include buurten

### DIFF
--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -69,7 +69,7 @@ def _init():
     print("Succesfully initialized message broker")
 
 
-def messagedriven_service(services, name="UNKNOWN"):
+def messagedriven_service(services, name):
     """Start a connection with a the message broker and the given definition
 
     servicedefenition is a dict of dicts:

--- a/gobcore/model/__init__.py
+++ b/gobcore/model/__init__.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+from gobcore.model.metadata import STATE_FIELDS
+
 
 class GOBModel():
     def __init__(self):
@@ -21,9 +23,16 @@ class GOBModel():
             for entity_name, model in catalog['collections'].items():
                 model['references'] = self._extract_references(model['attributes'])
 
+                model_attributes = model['attributes']
+                state_attributes = STATE_FIELDS if model.get('has_states') else {}
+                all_attributes = {
+                    **state_attributes,
+                    **model_attributes
+                }
+
                 # Add fields to the GOBModel to be used in database creation and lookups
                 model['fields'] = {
-                    field_name: attributes for field_name, attributes in model['attributes'].items()
+                    field_name: attributes for field_name, attributes in all_attributes.items()
                 }
 
     def _extract_references(self, attributes):

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -225,11 +225,11 @@
           },
           "hoogte_tov_nap": {
             "type": "GOB.Decimal",
-            "description": "Hoog­te van het re­fe­ren­tie­punt t.o.v. NAP"
+            "description": "Hoogte van het referentiepunt t.o.v. NAP"
           },
           "datum": {
             "type": "GOB.Date",
-            "description": "Da­tum van plaat­sing van het re­fe­ren­tie­punt."
+            "description": "Datum van plaatsing van het referentiepunt."
           },
           "status": {
             "type": "GOB.JSON",
@@ -277,7 +277,7 @@
           },
           "is_nap_peilmerk": {
             "type": "GOB.Reference",
-            "description": "Het NAP-peil­merk dat het re­fe­ren­tie­punt kan zijn.",
+            "description": "Het NAP-peilmerk dat het referentiepunt kan zijn.",
             "ref": "nap:peilmerken"
           },
           "publiceerbaar": {
@@ -332,19 +332,19 @@
     "collections": {
       "peilmerken": {
         "version": "0.1",
-        "entity_id": "peilmerknummer",
+        "entity_id": "identificatie",
         "attributes": {
           "identificatie": {
             "type": "GOB.String",
-            "description": "Het peilmerknum­mer van het peil­merk."
+            "description": "Het peilmerknummer van het peilmerk."
           },
           "hoogte_tov_nap": {
             "type": "GOB.Decimal",
-            "description": "Hoog­te van het peilmerk t.o.v. NAP"
+            "description": "Hoogte van het peilmerk t.o.v. NAP"
           },
           "jaar": {
             "type": "GOB.Integer",
-            "description": "Het jaar van wa­ter­pas­sing, be­ho­ren­de bij de hoog­te."
+            "description": "Het jaar van waterpassing, behorende bij de hoogte."
           },
           "merk": {
             "type": "GOB.JSON",
@@ -352,7 +352,7 @@
           },
           "omschrijving": {
             "type": "GOB.String",
-            "description": "Be­schrij­ving van het ob­ject waar­in het peil­merk zich be­vindt."
+            "description": "Beschrijving van het object waarin het peilmerk zich bevindt."
           },
           "windrichting": {
             "type": "GOB.String",
@@ -368,7 +368,7 @@
           },
           "rws_nummer": {
             "type": "GOB.String",
-            "description": "Num­mer dat Rijks­wa­ter­staat han­teert."
+            "description": "Nummer dat Rijkswaterstaat hanteert."
           },
           "geometrie": {
             "type": "GOB.Geo.Point",
@@ -404,6 +404,64 @@
               "field": "publiceerbaar",
               "op": "==",
               "value": true
+            }
+          ]
+        }
+      }
+    }
+  },
+  "gebieden": {
+    "version": "0.1",
+    "description": "Gebieden in Amsterdam.",
+    "collections": {
+      "buurten": {
+        "version": "0.1",
+        "entity_id": "identificatie",
+        "has_states": true,
+        "attributes": {
+          "identificatie": {
+            "type": "GOB.String",
+            "description": "Unieke identificatie van het object."
+          },
+          "naam": {
+            "type": "GOB.String",
+            "description": "De naam van het object."
+          },
+          "code": {
+            "type": "GOB.String",
+            "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode."
+          },
+          "datum_begin_geldigheid": {
+            "type": "GOB.Date",
+            "description": "De datum waarop het object is gecreëerd."
+          },
+          "datum_einde_geldigheid": {
+            "type": "GOB.Date",
+            "description": "De datum waarop het object is komen te vervallen."
+          },
+          "documentdatum": {
+            "type": "GOB.Date",
+            "description": "De datum waarop het document is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+          },
+          "documentnummer": {
+            "type": "GOB.String",
+            "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
+          },
+          "ligt_in_wijk": {
+            "type": "GOB.Reference",
+            "description": "De wijk waar de buurt in ligt.",
+            "ref": "gebieden:wijken"
+          },
+          "geometrie": {
+            "type": "GOB.Geo.Polygon",
+            "description": "Geometrische beschrijving van een object."
+          }
+        },
+        "api": {
+          "filters": [
+            {
+              "field": "datum_einde_geldigheid",
+              "op": "is_null"
             }
           ]
         }

--- a/gobcore/model/metadata.py
+++ b/gobcore/model/metadata.py
@@ -9,6 +9,22 @@ The auto-included attributes have the purpose of
 
 """
 
+"""Description of all fields that are automatically added to each entity"""
+DESCRIPTION = {
+    "_version": "",
+    "_date_created": "Timestamp telling when the entity has last been created in GOB.",
+    "_date_confirmed": "Timestamp telling when the entity has last been confirmed in GOB.",
+    "_date_modified": "Timestamp telling when the entity has last been modified in GOB.",
+    "_date_deleted": "Timestamp telling when the entity has last been deleted in GOB.",
+    "_source": "Source for the specific entity, eg the name of a database.",
+    "_source_id": "Id of the entity in the above mentioned source.",
+    "_last_event": "Id of the last event that has been applied to this entity.",
+    "_gobid": "The internal GOB id of the entity.",
+    "_id": "Provide for a generic (independent from Stelselpedia) id field for every entity.",
+    "volgnummer": "Uniek volgnummer van de toestand van het object.",
+    "registratiedatum": "De datum waarop de toestand is geregistreerd."
+}
+
 """Meta data that is registered for every entity"""
 METADATA_COLUMNS = {
     # Public meta information about each row in a table
@@ -28,28 +44,41 @@ METADATA_COLUMNS = {
     # On applying the event this state is compared with the current state
     # Only when these two match the event will be applied, otherwise the event will be rejected.
     "private": {
-        "_source": "GOB.String",  # Source for the specific entity, eg the name of a database
-        "_source_id": "GOB.String",  # Id of the entity in the above mentioned source
-        "_last_event": "GOB.Integer"  # Id of the last event that has been applied to this entity
+        "_source": "GOB.String",
+        "_source_id": "GOB.String",
+        "_last_event": "GOB.Integer"
     }
 }
 
 """Columns that are at the start of each entity"""
 FIXED_COLUMNS = {
-    "_gobid": "GOB.PKInteger",  # The internal (GOB) id of the entity
-    "_id": "GOB.String"         # Provide for a generic (independent from Stelselpedia) id field for every entity
+    "_gobid": "GOB.PKInteger",
+    "_id": "GOB.String"
+}
+
+"""Columns that are part of entities that have states"""
+STATE_COLUMNS = {
+    "volgnummer": "GOB.String",
+    "registratiedatum": "GOB.DateTime"
 }
 
 PRIVATE_META_FIELDS = {
         field_name: {
             "type": field_type,
-            "description": ""
+            "description": DESCRIPTION[field_name]
         } for field_name, field_type in METADATA_COLUMNS["private"].items()
     }
 
 PUBLIC_META_FIELDS = {
         field_name: {
             "type": field_type,
-            "description": ""
+            "description": DESCRIPTION[field_name]
         } for field_name, field_type in METADATA_COLUMNS["public"].items()
     }
+
+STATE_FIELDS = {
+    field_name: {
+        "type": field_type,
+        "description": DESCRIPTION[field_name]
+    } for field_name, field_type in STATE_COLUMNS.items()
+}

--- a/gobcore/typesystem/__init__.py
+++ b/gobcore/typesystem/__init__.py
@@ -31,7 +31,8 @@ GOB_TYPES = [
 ]
 
 GEO_TYPES = [
-    GEO.Point
+    GEO.Point,
+    GEO.Polygon
 ]
 
 # Convert GOB_TYPES to a dictionary indexed by the name of the type, prefixed by GOB.

--- a/gobcore/typesystem/gob_geotypes.py
+++ b/gobcore/typesystem/gob_geotypes.py
@@ -139,3 +139,53 @@ class Point(GEOType):
     def get_column_definition(cls, column_name, **kwargs):
         srid = kwargs['srid'] if 'srid' in kwargs else cls._srid
         return sqlalchemy.Column(column_name, geoalchemy2.Geometry(geometry_type='POINT', srid=srid))
+
+class Polygon(GEOType):
+    # POLYGON ((115145.619264024 485115.91328199, ...))
+    name = "Polygon"
+    sql_type = geoalchemy2.Geometry('POLYGON')
+
+    @classmethod  # noqa: C901
+    def from_value(cls, value, **kwargs):
+        """Instantiates the GOBType Point, with either a database value, a geojson or WKT string"""
+
+        if isinstance(value, str):
+            regex = re.compile("^POLYGON\s*\(\([0-9\s\.,]*\)\)$")
+            if not regex.match(value):
+                raise ValueError(f"Illegal WKT value: {value}")
+
+        if isinstance(value, geoalchemy2.elements.WKBElement):
+            # Use shapely to construct wkt string and use wkt load to get correct precision
+            value = wkt.loads(to_shape(value).wkt)
+
+        if isinstance(value, dict):
+            # serialize possible geojson
+            value = json.dumps(value, cls=GobTypeJSONEncoder)
+
+        # if is geojson dump to wkt string
+        try:
+            precision = kwargs['precision'] if 'precision' in kwargs else cls._precision
+            wkt_string = wkt.dumps(json.loads(value), decimals=precision)
+            value = wkt_string
+
+            # it is not a to wkt_string dumpable json, let it pass:
+        except JSONDecodeError:
+            pass
+        except TypeError:
+            pass
+
+        # is wkt string
+        return cls(value)
+
+    @classmethod
+    def from_values(cls, **values):
+        """Instantiate a Point, using x and y coordinates, and optional srid:
+
+            point = Point.from_values(x=1, y=2, srid=28992)
+        """
+        raise ValueError(f"NYI")
+
+    @classmethod
+    def get_column_definition(cls, column_name, **kwargs):
+        srid = kwargs['srid'] if 'srid' in kwargs else cls._srid
+        return sqlalchemy.Column(column_name, geoalchemy2.Geometry(geometry_type='POLYGON', srid=srid))

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -335,14 +335,20 @@ class DateTime(Date):
         input_format = kwargs['format'] if 'format' in kwargs else cls.internal_format
 
         if value is not None:
-            # Convert to isoformat if value is a datetime object
-            value = value.isoformat() if isinstance(value, datetime.datetime) else value
             try:
-                value = datetime.datetime.strptime(str(value), input_format).strftime(cls.internal_format)
+                if not isinstance(value, datetime.datetime):
+                    value = datetime.datetime.strptime(str(value), input_format)
+                value = value.strftime(cls.internal_format)
             except ValueError as v:
                 raise GOBTypeException(v)
 
         return cls(str(value)) if value is not None else cls(None)
+
+    @property
+    def to_db(self):
+        if self._string is None:
+            return None
+        return datetime.datetime.strptime(self._string, self.internal_format)
 
 
 class JSON(GOBType):


### PR DESCRIPTION
State columns denote columns that are added to each entity that
has states. Gebieden have states where each state has a
start date, end date and a sequence number and registration date.

The sequence number and registration date are required for every
entity that has states and are added automatically.

Polygon type is used for gebieden import.

Buurten is the first entity that has been imported from the
gebieden collection