### PR TITLE
Improve robustness of message handler

### DIFF
--- a/gobcore/message_broker/async_message_broker.py
+++ b/gobcore/message_broker/async_message_broker.py
@@ -280,7 +280,7 @@ class AsyncConnection(object):
 
                         # Allow for offline contents
                         msg, offload_id = load_message(msg, from_json)
-                    except json.decoder.JSONDecodeError:
+                    except (TypeError, json.decoder.JSONDecodeError):
                         # message was not json, pass message as it is received
                         msg = body
 

--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -48,7 +48,7 @@ def log_error(msg, cause_msg, err):
 
     # Include the header to associate the log message with the correct processid
     logger.error(msg, extra={
-        **cause_msg['header'],
+        **cause_msg.get('header', {}),
         "data": {
             "error": str(err)   # Include a short error description
         }

--- a/gobcore/message_broker/offline_contents.py
+++ b/gobcore/message_broker/offline_contents.py
@@ -89,9 +89,14 @@ def load_message(msg, converter):
 def end_message(unique_name):
     """Remove the offloaded contents after a message has been succesfully handled
 
-    :param msg:
-    :return:
+    end_message can always be called, it can never fail
+
+    :param unique_name: the id of any offloaded contents
+    :return: None
     """
     if unique_name:
-        filename = _get_filename(unique_name)
-        os.remove(filename)
+        try:
+            filename = _get_filename(unique_name)
+            os.remove(filename)
+        except Exception:
+            pass

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest
 
 echo "Running coverage tests"
-pytest --cov=gobcore --cov-report html --cov-fail-under=82
+pytest --cov=gobcore --cov-report html --cov-fail-under=84

--- a/tests/gobcore/message_broker/test_message_broker.py
+++ b/tests/gobcore/message_broker/test_message_broker.py
@@ -280,5 +280,14 @@ def test_subscribe(monkeypatch):
     }
     connection.subscribe([queue, queue], on_message)
     connection.publish(queue, "key", "mybody")
-    connection.disconnect()
     assert(consumed_message == "mybody")
+
+    # connection, exchange, queue, key, msg
+    def on_message_fail(self, exchange, queue, key, body):
+        raise Exception
+
+    connection.subscribe([queue, queue], on_message_fail)
+    connection.publish(queue, "key", "mybody")
+    assert(consumed_message == "mybody")
+
+    connection.disconnect()


### PR DESCRIPTION
Catch all message handler exceptions
Always acknowledge message, except when explicitly declared not to do so (result == False)
Failing messages are so removed from the queue