### PR TITLE
Allow for skipping result message

### DIFF
--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -77,7 +77,7 @@ def _on_message(connection, service, msg):
         return True
 
     # If a report_queue
-    if 'report' in service:
+    if 'report' in service and not result_msg is None:
         report = service['report']
         connection.publish(report, report['key'], result_msg)
 

--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -77,7 +77,7 @@ def _on_message(connection, service, msg):
         return True
 
     # If a report_queue
-    if 'report' in service and not result_msg is None:
+    if 'report' in service and result_msg is not None:
         report = service['report']
         connection.publish(report, report['key'], result_msg)
 


### PR DESCRIPTION
When the result message is None the sending of a report message,
if so defined, is skipped