### PR TITLE
Add application to event

### DIFF
--- a/gobcore/events/__init__.py
+++ b/gobcore/events/__init__.py
@@ -38,35 +38,53 @@ def _get_event(name):
         raise GOBException(f"{name} is an invalid GOB event")
 
 
-def get_event_for(entity, data, metadata, modifications):
+def get_event_for(old_data, new_data, modifications):
     """
-    Get the event dict for the given entity, source-data, metadata and calculated modifications
+    Get the event for the given entity, source-data, metadata and calculated modifications
 
-    :param entity:
-    :param data:
-    :param metadata:
-    :param modifications:
+    :param old_data: the entity data as stored in the database
+    :param new_data: the entity data as received in the message
+    :param modifications: the list of modifications for the entity (old_data - new_data)
 
-    :return: the event dict
+    :return: the event that corresponds with the given parameters
     """
-    has_old_state = entity is not None
-    has_new_state = data is not None
+    has_old_state = old_data is not None
+    has_new_state = new_data is not None
+    assert has_old_state or has_new_state, "Event without old or new state"
+
     has_modifications = len(modifications) > 0
 
+    # Get the event class (ADD, MODIFY, CONFIRM, DELETE)
     gob_event = _get_event_class_for(has_old_state, has_new_state, has_modifications)
 
-    # get relevenant id's from either entity or data
-    _source_id = data["_source_id"] if has_new_state else None
     if has_old_state:
-        _entity_source_id = entity._source_id
-        last_event = entity._last_event
+        # MODIFY, CONFIRM, DELETE
+        # Attach event to the previous event for the entity
+        _last_event = old_data._last_event
+        # The source_id might change, so save the old entity source_id
+        _entity_source_id = old_data._source_id
     else:
-        _entity_source_id = _source_id
-        last_event = None
+        # ADD
+        # No previous event, entity source id is equal to the new source id
+        _last_event = None
+        _entity_source_id = new_data["_source_id"]
 
-    modifications_dict = dict(modifications=modifications)
-    data = modifications_dict if data is None else {**modifications_dict, **data}
-    data = {**data, "_last_event": last_event}
+    if has_new_state:
+        # ADD, MODIFY, CONFIRM
+        # Register the source of the event
+        _source_id = new_data["_source_id"]
+    else:
+        # DELETE
+        # No new source id, keep existing source id
+        _source_id = old_data._source_id
+
+    # The event data are the modifications
+    data = dict(modifications=modifications)
+    data["_last_event"] = _last_event
+    if has_new_state:
+        # Merge the new state data (possible ADD event)
+        # The ultimate event class will filter either the modifications (MODIFY) or the new data (ADD)
+        data.update(new_data)
 
     return gob_event.create_event(_source_id, _entity_source_id, data)
 

--- a/gobcore/events/__init__.py
+++ b/gobcore/events/__init__.py
@@ -56,18 +56,19 @@ def get_event_for(entity, data, metadata, modifications):
     gob_event = _get_event_class_for(has_old_state, has_new_state, has_modifications)
 
     # get relevenant id's from either entity or data
+    _source_id = data["_source_id"] if has_new_state else None
     if has_old_state:
-        source_id = entity._source_id
+        _entity_source_id = entity._source_id
         last_event = entity._last_event
     else:
-        source_id = data['_source_id']
+        _entity_source_id = _source_id
         last_event = None
 
     modifications_dict = dict(modifications=modifications)
     data = modifications_dict if data is None else {**modifications_dict, **data}
     data = {**data, "_last_event": last_event}
 
-    return gob_event.create_event(source_id, data)
+    return gob_event.create_event(_source_id, _entity_source_id, data)
 
 
 def _get_event_class_for(has_old_state, has_new_state, has_modifications):

--- a/gobcore/events/__init__.py
+++ b/gobcore/events/__init__.py
@@ -58,19 +58,16 @@ def get_event_for(entity, data, metadata, modifications):
     # get relevenant id's from either entity or data
     if has_old_state:
         source_id = entity._source_id
-        entity_id = getattr(entity, metadata.id_column)
         last_event = entity._last_event
     else:
         source_id = data['_source_id']
-        entity_id = data[metadata.id_column]
         last_event = None
 
     modifications_dict = dict(modifications=modifications)
     data = modifications_dict if data is None else {**modifications_dict, **data}
     data = {**data, "_last_event": last_event}
 
-    return gob_event.create_event(
-        source_id, metadata.id_column, entity_id, data)
+    return gob_event.create_event(source_id, data)
 
 
 def _get_event_class_for(has_old_state, has_new_state, has_modifications):

--- a/gobcore/events/import_events.py
+++ b/gobcore/events/import_events.py
@@ -61,9 +61,10 @@ class ImportEvent(metaclass=ABCMeta):
 
         :return: entity_id, source_id: ids of this event
         """
-        source_id = self._data.pop(self._metadata.source_id_column)
-
-        return source_id
+        # source_id = self._data.pop(self._metadata.source_id_column)
+        #
+        # return source_id
+        pass
 
     def apply_to(self, entity):
         """Sets the attributes in data on the entity (expands `data['mutations'] first)
@@ -76,10 +77,13 @@ class ImportEvent(metaclass=ABCMeta):
         setattr(entity, self.timestamp_field, self._metadata.timestamp)
         # Register the application that delivered the event
         entity._application = self._metadata.application
+        # And the id of the entity within the application
+        entity._source_id = self._data["_source_id"]
 
         for key, value in self._data.items():
-            gob_type = get_gob_type(self._model['fields'][key]['type'])
-            setattr(entity, key, gob_type.from_value(value).to_db)
+            if key != "_source_id":
+                gob_type = get_gob_type(self._model['fields'][key]['type'])
+                setattr(entity, key, gob_type.from_value(value).to_db)
 
 
 class ADD(ImportEvent):

--- a/gobcore/events/import_events.py
+++ b/gobcore/events/import_events.py
@@ -53,20 +53,6 @@ class ImportEvent(metaclass=ABCMeta):
         self.last_event = self._data.pop("_last_event")
         self._model = self.gob_model.get_collection(self._metadata.catalogue, self._metadata.entity)
 
-    def pop_ids(self):
-        """Removes and returns relevent ids
-
-        Todo: decide if putting them in (see abstract class-method `create_event`)
-              and popping them off is the right way
-              Given the metadata, these could be derived
-
-        :return: entity_id, source_id: ids of this event
-        """
-        # source_id = self._data.pop(self._metadata.source_id_column)
-        #
-        # return source_id
-        pass
-
     def apply_to(self, entity):
         """Sets the attributes in data on the entity (expands `data['mutations'] first)
 
@@ -115,7 +101,6 @@ class ADD(ImportEvent):
         # The _last_event and other meta info is set seperately from the entity update
         self._data = self._data["entity"]
         del self._data["_last_event"]
-        self.pop_ids()
 
         super().apply_to(entity)
 

--- a/gobcore/events/import_events.py
+++ b/gobcore/events/import_events.py
@@ -72,7 +72,10 @@ class ImportEvent(metaclass=ABCMeta):
         :param metadata: the metadata of the import message
         :return:
         """
+        # Register the time that the event has been applied to the entity
         setattr(entity, self.timestamp_field, self._metadata.timestamp)
+        # Register the application that delivered the event
+        entity._application = self._metadata.application
 
         for key, value in self._data.items():
             gob_type = get_gob_type(self._model['fields'][key]['type'])

--- a/gobcore/events/import_message.py
+++ b/gobcore/events/import_message.py
@@ -19,6 +19,10 @@ class MessageMetaData():
         return self._header['source']
 
     @property
+    def application(self):
+        return self._header['application']
+
+    @property
     def timestamp(self):
         return self._header['timestamp']
 
@@ -46,6 +50,7 @@ class MessageMetaData():
     def as_header(self):
         return {
             "source": self.source,
+            "application": self.application,
             "timestamp": self.timestamp,
             "catalogue": self.catalogue,
             "entity": self.entity,

--- a/gobcore/events/import_message.py
+++ b/gobcore/events/import_message.py
@@ -23,10 +23,6 @@ class MessageMetaData():
         return self._header['timestamp']
 
     @property
-    def id_column(self):
-        return self._header['id_column']
-
-    @property
     def catalogue(self):
         return self._header['catalogue']
 
@@ -51,7 +47,6 @@ class MessageMetaData():
         return {
             "source": self.source,
             "timestamp": self.timestamp,
-            "id_column": self.id_column,
             "catalogue": self.catalogue,
             "entity": self.entity,
             "version": self.version,

--- a/gobcore/events/import_message.py
+++ b/gobcore/events/import_message.py
@@ -9,8 +9,6 @@ Todo: Name of the module (message) should correspond to the contents of the file
 
 class MessageMetaData():
 
-    source_id_column = '_source_id'
-
     def __init__(self, header):
         self._header = header
 

--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -70,7 +70,7 @@ def _on_message(connection, service, msg):
     except Exception as err:
         # Print error message, the message that caused the error and a short stacktrace
         stacktrace = traceback.format_exc(limit=-5)
-        print("Message processing has failed, further processing stopped", msg, stacktrace)
+        print("Message processing has failed, further processing stopped", stacktrace)
         # Log the error and a short error description
         log_error(f"Message processing has failed, further processing stopped", msg, err)
         # Message has caused a crash, remove the message from the queue by returning true

--- a/gobcore/model/__init__.py
+++ b/gobcore/model/__init__.py
@@ -3,6 +3,32 @@ import json
 
 from gobcore.model.metadata import STATE_FIELDS
 
+EVENTS_DESCRIPTION = {
+    "eventid": "Unique identification of the event, numbered sequentially",
+    "timestamp": "Datetime when the event as created",
+    "catalogue": "The catalogue in which the entity resides",
+    "entity": "The entity to which the event need to be applied",
+    "version": "The version of the entity model",
+    "action": "Add, change, delete or confirm",
+    "source": "The functional source of the entity, e.g. AMSBI",
+    "application": "The technical source of the entity, e.g. DIVA",
+    "source_id": "The id of the entity in the source",
+    "contents": "A json object that holds the contents for the action, the full entity for an Add"
+}
+
+EVENTS = {
+    "eventid": "GOB.PKInteger",
+    "timestamp": "GOB.DateTime",
+    "catalogue": "GOB.String",
+    "entity": "GOB.String",
+    "version": "GOB.String",
+    "action": "GOB.String",
+    "source": "GOB.String",
+    "application": "GOB.String",
+    "source_id": "GOB.String",
+    "contents": "GOB.JSON"
+}
+
 
 class GOBModel():
     def __init__(self):

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -5,7 +5,7 @@
     "collections": {
       "test_entity": {
         "version": "0.1",
-        "entity_id": "testid",
+        "entity_id": "string",
         "attributes": {
           "string": {
             "type": "GOB.String",
@@ -116,11 +116,6 @@
         "api": {
           "filters": [
             {
-              "field": "_source",
-              "op": "==",
-              "value": "Grondslag"
-            },
-            {
               "field": "publiceerbaar",
               "op": "==",
               "value": true
@@ -193,11 +188,6 @@
         },
         "api": {
           "filters": [
-            {
-              "field": "_source",
-              "op": "==",
-              "value": "Grondslag"
-            },
             {
               "field": "publiceerbaar",
               "op": "==",
@@ -288,11 +278,6 @@
         "api": {
           "filters": [
             {
-              "field": "_source",
-              "op": "==",
-              "value": "Grondslag"
-            },
-            {
               "field": "publiceerbaar",
               "op": "==",
               "value": true
@@ -315,13 +300,7 @@
           }
         },
         "api": {
-          "filters": [
-            {
-              "field": "_source",
-              "op": "==",
-              "value": "Basisinformatie"
-            }
-          ]
+          "filters": []
         }
       }
     }
@@ -395,11 +374,6 @@
         },
         "api": {
           "filters": [
-            {
-              "field": "_source",
-              "op": "==",
-              "value": "Grondslag"
-            },
             {
               "field": "publiceerbaar",
               "op": "==",

--- a/gobcore/model/metadata.py
+++ b/gobcore/model/metadata.py
@@ -16,8 +16,9 @@ DESCRIPTION = {
     "_date_confirmed": "Timestamp telling when the entity has last been confirmed in GOB.",
     "_date_modified": "Timestamp telling when the entity has last been modified in GOB.",
     "_date_deleted": "Timestamp telling when the entity has last been deleted in GOB.",
-    "_source": "Source for the specific entity, eg the name of a database.",
-    "_source_id": "Id of the entity in the above mentioned source.",
+    "_source": "Functional source for the specific entity, eg the name of a department.",
+    "_application": "Technical source for the specific entity, eg the name of a database.",
+    "_source_id": "Id of the entity in the above mentioned source application.",
     "_last_event": "Id of the last event that has been applied to this entity.",
     "_gobid": "The internal GOB id of the entity.",
     "_id": "Provide for a generic (independent from Stelselpedia) id field for every entity.",
@@ -45,6 +46,7 @@ METADATA_COLUMNS = {
     # Only when these two match the event will be applied, otherwise the event will be rejected.
     "private": {
         "_source": "GOB.String",
+        "_application": "GOB.String",
         "_source_id": "GOB.String",
         "_last_event": "GOB.Integer"
     }

--- a/gobcore/model/sa/gob.py
+++ b/gobcore/model/sa/gob.py
@@ -7,36 +7,12 @@ from sqlalchemy import Index
 from sqlalchemy.ext.declarative import declarative_base
 
 # Import data definitions
-from gobcore.model import GOBModel
+from gobcore.model import GOBModel, EVENTS, EVENTS_DESCRIPTION
 from gobcore.model.metadata import FIXED_FIELDS, PRIVATE_META_FIELDS, PUBLIC_META_FIELDS, STATE_FIELDS
 from gobcore.model.metadata import columns_to_fields
 from gobcore.typesystem import get_gob_type
 
 Base = declarative_base()
-
-EVENTS_DESCRIPTION = {
-    "eventid": "Unique identification of the event, numbered sequentially",
-    "timestamp": "Datetime when the event as created",
-    "catalogue": "The catalogue in which the entity resides",
-    "entity": "The entity to which the event need to be applied",
-    "version": "The version of the entity model",
-    "action": "Add, change, delete or confirm",
-    "source": "The source of the entity, e.g. DIVA",
-    "source_id": "The id of the entity in the source",
-    "contents": "A json object that holds the contents for the action, the full entity for an Add"
-}
-
-EVENTS = {
-    "eventid": "GOB.PKInteger",
-    "timestamp": "GOB.DateTime",
-    "catalogue": "GOB.String",
-    "entity": "GOB.String",
-    "version": "GOB.String",
-    "action": "GOB.String",
-    "source": "GOB.String",
-    "source_id": "GOB.String",
-    "contents": "GOB.JSON"
-}
 
 
 def get_column(column_name, column_specification):

--- a/tests/gobcore/events/test_message.py
+++ b/tests/gobcore/events/test_message.py
@@ -13,7 +13,7 @@ class TestEvents(unittest.TestCase):
         metadata = fixtures.get_metadata_fixture()
 
         header = metadata.as_header
-        keys = ['source', 'timestamp', 'entity', 'version', 'process_id', 'model']
+        keys = ['source', 'timestamp', 'entity', 'version', 'process_id', 'model', 'application']
         for key in keys:
             self.assertIn(key, header)
 

--- a/tests/gobcore/events/test_message.py
+++ b/tests/gobcore/events/test_message.py
@@ -13,7 +13,7 @@ class TestEvents(unittest.TestCase):
         metadata = fixtures.get_metadata_fixture()
 
         header = metadata.as_header
-        keys = ['source', 'timestamp', 'id_column', 'entity', 'version', 'process_id', 'model']
+        keys = ['source', 'timestamp', 'entity', 'version', 'process_id', 'model']
         for key in keys:
             self.assertIn(key, header)
 

--- a/tests/gobcore/fixtures.py
+++ b/tests/gobcore/fixtures.py
@@ -49,7 +49,7 @@ def get_event_fixture():
 
 
 def get_metadata_fixture():
-    header = {key: random_string() for key in ["source", "timestamp", "version", "model"]}
+    header = {key: random_string() for key in ["source", "timestamp", "version", "model", "application"]}
     header['catalogue'] = 'meetbouten'
     header['entity'] = 'meetbouten'
     header['id_column'] = 'meetboutid'

--- a/tests/gobcore/fixtures.py
+++ b/tests/gobcore/fixtures.py
@@ -45,7 +45,7 @@ def get_event_data_fixture(gob_event):
 def get_event_fixture():
     gob_event = random_gob_event()
     data = get_event_data_fixture(gob_event)
-    return gob_event.create_event(random_string(), data)
+    return gob_event.create_event(random_string(), random_string(), data)
 
 
 def get_metadata_fixture():

--- a/tests/gobcore/fixtures.py
+++ b/tests/gobcore/fixtures.py
@@ -45,7 +45,7 @@ def get_event_data_fixture(gob_event):
 def get_event_fixture():
     gob_event = random_gob_event()
     data = get_event_data_fixture(gob_event)
-    return gob_event.create_event(random_string(), random_string(), random_string(), data)
+    return gob_event.create_event(random_string(), data)
 
 
 def get_metadata_fixture():


### PR DESCRIPTION
Register the application that is responsible for the event in the event.
Allow for changes in source for an entity by registering the entity source id.

These changes allow for maintaining a functional collection that is build from different applications.