### PR TITLE
Remove isoformat in json for datetime

### DIFF
--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -350,11 +350,6 @@ class DateTime(Date):
             return None
         return datetime.datetime.strptime(self._string, self.internal_format)
 
-    @property
-    def json(self):
-        return json.dumps(datetime.datetime.strptime(self._string, self.internal_format).isoformat()) \
-               if self._string is not None else json.dumps(None)
-
 
 class JSON(GOBType):
     name = "JSON"


### PR DESCRIPTION
This resulted in an error when passing datetimes across the message bus. Isoformat will nog be handled in the API itself