### PR TITLE
Convert WKT geometries to include precision

### DIFF
--- a/gobcore/typesystem/gob_geotypes.py
+++ b/gobcore/typesystem/gob_geotypes.py
@@ -243,6 +243,8 @@ class Geometry(GEOType):
             regex = re.compile("^[A-Z]+\s*\([A-Z0-9.,\s\(\)]+\)$")
             if not regex.match(value):
                 raise ValueError(f"Illegal Geometry WKT value: {value}")
+            # Use wkt load to get correct precision
+            value = wkt.loads(value)
 
         if isinstance(value, geoalchemy2.elements.WKBElement):
             # Use shapely to construct wkt string and use wkt load to get correct precision

--- a/tests/gobcore/typesystem/test_geo_types.py
+++ b/tests/gobcore/typesystem/test_geo_types.py
@@ -47,7 +47,7 @@ class TestGobGeoTypes(unittest.TestCase):
         GobType = get_gob_type("GOB.Geo.Geometry")
         self.assertEqual(GobType.name, "Geometry")
 
-        self.assertEqual('POLYGON(112.0 22.0, 113.0 22.0, 113.0 21.0)', str(GobType.from_value('POLYGON(112.0 22.0, 113.0 22.0, 113.0 21.0)')))
+        self.assertEqual('POINT (1.000 2.000)', str(GobType.from_value('POINT (1 2)')))
 
         empty_geometry = GobType('')
         self.assertEqual('null', empty_geometry.json)


### PR DESCRIPTION
The precision of a WKT string needs to match the precision
specified in the Geo modulce