### PR TITLE
Do not prefetch messages

### DIFF
--- a/gobcore/message_broker/async_message_broker.py
+++ b/gobcore/message_broker/async_message_broker.py
@@ -112,7 +112,9 @@ class AsyncConnection(object):
             """
 
             # Handle max 1 message at the same time
-            channel.basic_qos(prefetch_count=1)
+            # Do not prefetch next message, just wait for processing to finish and then get next message
+            # This prevents messages to get queued after a long running earlier message and get delayed
+            channel.basic_qos(prefetch_count=1, prefetch_size=0)
 
             # If a callback has been defined for connection success, call this function
             if self._on_connect_callback:

--- a/tests/gobcore/message_broker/test_message_broker.py
+++ b/tests/gobcore/message_broker/test_message_broker.py
@@ -69,7 +69,7 @@ class MockChannel:
                   tag):
         pass
 
-    def basic_qos(self, prefetch_count):
+    def basic_qos(self, prefetch_count, prefetch_size):
         pass
 
     def queue_bind(self,


### PR DESCRIPTION
To prevent messages getting queued after
a long running previous message