### PR TITLE
Add hash to entities

### DIFF
--- a/gobcore/events/__init__.py
+++ b/gobcore/events/__init__.py
@@ -73,14 +73,18 @@ def get_event_for(old_data, new_data, modifications):
         # ADD, MODIFY, CONFIRM
         # Register the source of the event
         _source_id = new_data["_source_id"]
+        _hash = new_data["_hash"]
     else:
         # DELETE
         # No new source id, keep existing source id
         _source_id = old_data._source_id
+        _hash = None
 
     # The event data are the modifications
     data = dict(modifications=modifications)
     data["_last_event"] = _last_event
+    data["_hash"] = _hash
+
     if has_new_state:
         # Merge the new state data (possible ADD event)
         # The ultimate event class will filter either the modifications (MODIFY) or the new data (ADD)

--- a/gobcore/events/__init__.py
+++ b/gobcore/events/__init__.py
@@ -73,7 +73,7 @@ def get_event_for(old_data, new_data, modifications):
         # ADD, MODIFY, CONFIRM
         # Register the source of the event
         _source_id = new_data["_source_id"]
-        _hash = new_data["_hash"]
+        _hash = new_data[import_events.hash_key]
     else:
         # DELETE
         # No new source id, keep existing source id
@@ -83,7 +83,7 @@ def get_event_for(old_data, new_data, modifications):
     # The event data are the modifications
     data = dict(modifications=modifications)
     data["_last_event"] = _last_event
-    data["_hash"] = _hash
+    data[import_events.hash_key] = _hash
 
     if has_new_state:
         # Merge the new state data (possible ADD event)

--- a/gobcore/model/metadata.py
+++ b/gobcore/model/metadata.py
@@ -23,7 +23,8 @@ DESCRIPTION = {
     "_gobid": "The internal GOB id of the entity.",
     "_id": "Provide for a generic (independent from Stelselpedia) id field for every entity.",
     "volgnummer": "Uniek volgnummer van de toestand van het object.",
-    "registratiedatum": "De datum waarop de toestand is geregistreerd."
+    "registratiedatum": "De datum waarop de toestand is geregistreerd.",
+    "_hash": "A hash of the values of all public fields for comparison",
 }
 
 """Meta data that is registered for every entity"""
@@ -48,7 +49,8 @@ METADATA_COLUMNS = {
         "_source": "GOB.String",
         "_application": "GOB.String",
         "_source_id": "GOB.String",
-        "_last_event": "GOB.Integer"
+        "_last_event": "GOB.Integer",
+        "_hash": "GOB.String",
     }
 }
 

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest
 
 echo "Running coverage tests"
-pytest --cov=gobcore --cov-report html --cov-fail-under=84
+pytest --cov=gobcore --cov-report html --cov-fail-under=86

--- a/tests/gobcore/events/test_events.py
+++ b/tests/gobcore/events/test_events.py
@@ -15,6 +15,38 @@ class TestEvents(unittest.TestCase):
         with self.assertRaises(GOBException):
             events._get_event(fixtures.random_string())
 
+    def test_get_event_for_creates_add(self):
+        old_data = None
+        new_data = fixtures.get_data_fixture()
+        modifications = []
+
+        event = events.get_event_for(old_data, new_data, modifications)
+        self.assertEqual(event["event"], "ADD")
+
+    def test_get_event_for_creates_confirm(self):
+        new_data = fixtures.get_data_fixture()
+        old_data = fixtures.get_entity_fixture(new_data)
+        modifications = []
+
+        event = events.get_event_for(old_data, new_data, modifications)
+        self.assertEqual(event["event"], "CONFIRM")
+
+    def test_get_event_for_creates_modify(self):
+        new_data = fixtures.get_data_fixture()
+        old_data = fixtures.get_entity_fixture(fixtures.get_data_fixture())
+        modifications = [{'key': 'value'}]
+
+        event = events.get_event_for(old_data, new_data, modifications)
+        self.assertEqual(event["event"], "MODIFY")
+
+    def test_get_event_for_creates_modify(self):
+        new_data = None
+        old_data = fixtures.get_entity_fixture(fixtures.get_data_fixture())
+        modifications = []
+
+        event = events.get_event_for(old_data, new_data, modifications)
+        self.assertEqual(event["event"], "DELETE")
+
     def test_get_event_class_for(self):
         with self.assertRaises(GOBException):
             events._get_event_class_for(has_old_state=False, has_new_state=False,

--- a/tests/gobcore/fixtures.py
+++ b/tests/gobcore/fixtures.py
@@ -6,6 +6,12 @@ from gobcore.events import import_events
 from gobcore.events.import_message import MessageMetaData
 
 
+class Entity(object):
+    def __init__(self, initial_data):
+        for key in initial_data:
+            setattr(self, key, initial_data[key])
+
+
 def random_string(length=12, source=None):
     if source is None:
         source = string.ascii_letters
@@ -38,14 +44,28 @@ def random_gob_event():
 
 def get_event_data_fixture(gob_event):
     if gob_event.name == 'MODIFY':
-        return {import_events.modifications_key: {"_last_event": None}}
-    return {"_last_event": None}
+        return {import_events.modifications_key: {"_last_event": None}, import_events.hash_key: None}
+    return {"_last_event": None, import_events.hash_key: None}
 
 
 def get_event_fixture():
     gob_event = random_gob_event()
     data = get_event_data_fixture(gob_event)
     return gob_event.create_event(random_string(), random_string(), data)
+
+
+def get_data_fixture():
+    data = {
+        "_source_id": random_string(),
+        "_hash": random_string(),
+        "_last_event": random.randint(0, 100)
+    }
+    return data
+
+
+def get_entity_fixture(data):
+    entity = Entity(data)
+    return entity
 
 
 def get_metadata_fixture():


### PR DESCRIPTION
A hash field was added to be able to compare new data with the current state in the database. Tests were added to reach the required code coverage