### PR TITLE
Delete last_event only when it exists

### DIFF
--- a/gobcore/events/import_events.py
+++ b/gobcore/events/import_events.py
@@ -107,7 +107,8 @@ class ADD(ImportEvent):
         # Set the hash
         entity._hash = self._data[hash_key]
 
-        del self._data["_last_event"]
+        # Remove last_event from the data if it exists
+        self._data.pop("_last_event", None)
 
         super().apply_to(entity)
 


### PR DESCRIPTION
Last event is not filled for ADD events using the new comparison method, this deletes the key safely