### PR TITLE
Fix GOB dates for years < 1000

### DIFF
--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -309,7 +309,9 @@ class Date(String):
 
         if value is not None:
             try:
-                value = datetime.datetime.strptime(str(value), input_format).date().strftime(cls.internal_format)
+                value = datetime.datetime.strptime(str(value), input_format).date()
+                # Transform to internal string format and work around issue: https://bugs.python.org/issue13305
+                value = f"{value.year:04d}-" + value.strftime("%m-%d")
             except ValueError as v:
                 raise GOBTypeException(v)
 
@@ -338,7 +340,8 @@ class DateTime(Date):
             try:
                 if not isinstance(value, datetime.datetime):
                     value = datetime.datetime.strptime(str(value), input_format)
-                value = value.strftime(cls.internal_format)
+                # Transform to internal string format and work around issue: https://bugs.python.org/issue13305
+                value = f"{value.year:04d}-" + value.strftime("%m-%dT%H:%M:%S.%f")
             except ValueError as v:
                 raise GOBTypeException(v)
 

--- a/tests/gobcore/typesystem/test_gob_types.py
+++ b/tests/gobcore/typesystem/test_gob_types.py
@@ -163,6 +163,9 @@ class TestGobTypes(unittest.TestCase):
         self.assertEqual('"2016-05-04"', GobType.from_value('2016-05-04').json)
         self.assertEqual('"2016-05-04"', GobType.from_value('20160504', format="%Y%m%d").json)
 
+        # Test edge case https://bugs.python.org/issue13305 strftime is not consistent for years < 1000
+        self.assertEqual('"0001-05-04"', GobType.from_value('0001-05-04').json)
+
         with self.assertRaises(GOBException):
             GobType.from_value('N')
         with self.assertRaises(GOBException):
@@ -183,6 +186,10 @@ class TestGobTypes(unittest.TestCase):
 
         self.assertEqual('"2016-05-04T12:00:00.123000"', GobType.from_value('2016-05-04T12:00:00.123000').json)
         self.assertEqual('"2016-05-04T12:00:00.123000"', GobType.from_value('20160504 12:00:00.123000', format="%Y%m%d %H:%M:%S.%f").json)
+
+        # Test edge case https://bugs.python.org/issue13305 strftime is not consistent for years < 1000
+        self.assertEqual('"0005-05-04T12:00:00.123000"', GobType.from_value('0005-05-04T12:00:00.123000').json)
+        self.assertEqual('"0005-05-04T12:00:00.123000"', GobType.from_value('00050504 12:00:00.123000', format="%Y%m%d %H:%M:%S.%f").json)
 
         with self.assertRaises(GOBException):
             GobType.from_value('N')


### PR DESCRIPTION
Dates under < 1000 are outputted differently using strftime depending on the OS. See https://bugs.python.org/issue13305. A workaround was added to make sure dates are correct in the GOB typesystem