### PR TITLE
Add to_value function on typesystem

### DIFF
--- a/gobcore/typesystem/__init__.py
+++ b/gobcore/typesystem/__init__.py
@@ -120,3 +120,13 @@ def get_modifications(entity, data, model):     # noqa: C901
             modifications.append({'key': field_name, 'old_value': old_value, 'new_value': new_value})
 
     return modifications
+
+
+def get_value(entity):
+    """Get a dictionatry with python objects of an entity of GOBTypes
+
+    :param entity: an object with named attributes with values
+
+    :return: a dictionary of key, values
+    """
+    return {key: value.to_value for key, value in entity.items()}

--- a/gobcore/typesystem/gob_geotypes.py
+++ b/gobcore/typesystem/gob_geotypes.py
@@ -76,6 +76,10 @@ class GEOType(GOBType):
             return json.dumps(None)
         return json.dumps(wkt.loads(self._string))
 
+    @property
+    def to_value(self):
+        return self._string
+
 
 class Point(GEOType):
     name = "Point"

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -109,6 +109,15 @@ class GOBType(metaclass=ABCMeta):
         """
         pass
 
+    @property
+    @abstractmethod
+    def to_value(self):
+        """Python object of the GOBType instance
+
+        :return: Python object
+        """
+        pass
+
     @classmethod
     def get_column_definition(cls, column_name):
         """Returns the SQL Alchemy column definition for the type """
@@ -134,6 +143,10 @@ class String(GOBType):
 
     @property
     def to_db(self):
+        return self._string
+
+    @property
+    def to_value(self):
         return self._string
 
 
@@ -181,6 +194,10 @@ class Integer(String):
         if self._string is None:
             return None
         return int(self._string)
+
+    @property
+    def to_value(self):
+        return int(self._string) if self._string else None
 
 
 class PKInteger(Integer):
@@ -233,6 +250,10 @@ class Decimal(GOBType):
             return None
         return float(self._string)
 
+    @property
+    def to_value(self):
+        return self._string
+
 
 class Boolean(GOBType):
     name = "Boolean"
@@ -283,6 +304,10 @@ class Boolean(GOBType):
     def to_db(self):
         return self._bool()
 
+    @property
+    def to_value(self):
+        return self._bool()
+
     def _bool(self):
         if self._string == str(True):
             return True
@@ -319,6 +344,12 @@ class Date(String):
 
     @property
     def to_db(self):
+        if self._string is None:
+            return None
+        return datetime.datetime.strptime(self._string, self.internal_format)
+
+    @property
+    def to_value(self):
         if self._string is None:
             return None
         return datetime.datetime.strptime(self._string, self.internal_format)
@@ -391,6 +422,10 @@ class JSON(GOBType):
     @property
     def json(self):
         return self._string if self._string is not None else json.dumps(None)
+
+    @property
+    def to_value(self):
+        return json.loads(self._string)
 
 
 class Reference(JSON):

--- a/gobcore/typesystem/json.py
+++ b/gobcore/typesystem/json.py
@@ -1,7 +1,8 @@
+import datetime
 import decimal
 import json
 
-from gobcore.typesystem.gob_types import GOBType
+from gobcore.typesystem.gob_types import GOBType, Date, DateTime
 
 
 class GobTypeJSONEncoder(json.JSONEncoder):
@@ -24,4 +25,16 @@ class GobTypeJSONEncoder(json.JSONEncoder):
         if isinstance(obj, decimal.Decimal):
             return json.loads(str(obj))
 
-        return super().default(self, obj)
+        if isinstance(obj, datetime.date):
+            # First convert datetime to string and use GOBType to create JSON output
+            string_value = datetime.datetime.strftime(obj, Date.internal_format)
+            obj = Date.from_value(string_value, **{'format': Date.internal_format})
+            return json.loads(obj.json)
+
+        if isinstance(obj, datetime.datetime):
+            # First convert datetime to string and use GOBType to create JSON output
+            string_value = datetime.datetime.strftime(obj, DateTime.internal_format)
+            obj = DateTime.from_value(string_value, **{'format': DateTime.internal_format})
+            return json.loads(obj.json)
+
+        return super().default(obj)

--- a/tests/gobcore/typesystem/test_gob_types.py
+++ b/tests/gobcore/typesystem/test_gob_types.py
@@ -74,6 +74,9 @@ class TestGobTypes(unittest.TestCase):
         # DB ouptut is string
         self.assertIsInstance(GobType.from_value('O').to_db, str)
 
+        # Python value is string
+        self.assertIsInstance(GobType.from_value('O').to_value, str)
+
     def test_int(self):
         GobType = get_gob_type("GOB.Integer")
         self.assertEqual(GobType.name, "Integer")
@@ -84,6 +87,9 @@ class TestGobTypes(unittest.TestCase):
 
         # DB ouptut is int
         self.assertIsInstance(GobType.from_value('123').to_db, int)
+
+        # Python value is int
+        self.assertIsInstance(GobType.from_value('123').to_value, int)
 
         with self.assertRaises(GOBException):
             GobType.from_value('N')
@@ -104,6 +110,9 @@ class TestGobTypes(unittest.TestCase):
 
         # DB ouptut is float
         self.assertIsInstance(GobType.from_value('123').to_db, float)
+
+        # Python value is string
+        self.assertIsInstance(GobType.from_value('123').to_value, str)
 
         with self.assertRaises(GOBException):
             GobType.from_value("123,123")
@@ -132,6 +141,10 @@ class TestGobTypes(unittest.TestCase):
         self.assertIsNone(GobType.from_value(None).to_db)
         self.assertTrue(GobType.from_value(True).to_db)
         self.assertFalse(GobType.from_value(False).to_db)
+
+        self.assertIsNone(GobType.from_value(None).to_value)
+        self.assertTrue(GobType.from_value(True).to_value)
+        self.assertFalse(GobType.from_value(False).to_value)
 
         with self.assertRaises(GOBException):
             GobType.from_value('N')
@@ -176,6 +189,9 @@ class TestGobTypes(unittest.TestCase):
         # DB ouptut is datetime
         self.assertIsInstance(GobType.from_value('2016-05-04').to_db, datetime)
 
+        # Python value is datetime
+        self.assertIsInstance(GobType.from_value('2016-05-04').to_value, datetime)
+
     def test_datetime(self):
         GobType = get_gob_type("GOB.DateTime")
         self.assertEqual(GobType.name, "DateTime")
@@ -200,8 +216,15 @@ class TestGobTypes(unittest.TestCase):
 
         # DB ouptut is datetime
         self.assertIsInstance(GobType.from_value('2016-05-04T12:00:00.123000').to_db, datetime)
+
         # unless an empty string is entered
         self.assertIsNone(GobType.from_value(None).to_db)
+
+        # Python value is datetime
+        self.assertIsInstance(GobType.from_value('2016-05-04T12:00:00.123000').to_value, datetime)
+
+        # unless an empty string is entered
+        self.assertIsNone(GobType.from_value(None).to_value)
 
     def test_json(self):
         GobType = get_gob_type("GOB.JSON")
@@ -241,6 +264,9 @@ class TestGobTypes(unittest.TestCase):
 
         # DB ouptut is json
         self.assertIsInstance(GobType.from_value('{"key": "value"}').to_db, dict)
+
+        # Python value is dict
+        self.assertIsInstance(GobType.from_value('{"key": "value"}').to_value, dict)
 
     def test_reference(self):
         GobType = get_gob_type("GOB.Reference")


### PR DESCRIPTION
Converting data to gobtypes results in a memory increase, so a function was added to all types to return python values