### PR TITLE
Temporary offload all messages

### DIFF
--- a/gobcore/message_broker/offline_contents.py
+++ b/gobcore/message_broker/offline_contents.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from gobcore.message_broker.config import GOB_SHARED_DIR
 
-_MAX_CONTENTS_SIZE = 1024   # Any message contents larger than this size is stored offline
+_MAX_CONTENTS_SIZE = 0   # Any message contents larger than this size is stored offline
 _CONTENTS = "contents"      # The name of the message attribute to check for its contents
 _CONTENTS_REF = "contents_ref"  # The name of the message attribute to store the reference to the offloaded contents
 _MESSAGE_BROKER_FOLDER = "message_broker"   # The name of the folder where the offloaded contents are stored
@@ -45,7 +45,7 @@ def _get_filename(name):
 
 
 def offload_message(msg, converter):
-    """Offload a message if its contents is too big
+    """Offload message content
 
     :param msg:
     :param converter:

--- a/tests/gobcore/message_broker/test_offline_contents.py
+++ b/tests/gobcore/message_broker/test_offline_contents.py
@@ -61,6 +61,8 @@ class TestOfflineContents(unittest.TestCase):
             handle = mocked_writer()
             handle.write.assert_called_once_with('converted contents')
 
+        '''
+        Temporary disabled until a solution for sizeof is found
         # Only offload large messages
         oc._MAX_CONTENTS_SIZE = 1024
 
@@ -69,6 +71,7 @@ class TestOfflineContents(unittest.TestCase):
             self.assertEqual(oc.offload_message({"contents": "contents", "any": "value"}, converter),
                              {"contents": "contents", "any": "value"})
             self.assertFalse(mocked_writer.called)
+        '''
 
     @mock.patch('gobcore.message_broker.offline_contents._get_filename', return_value="filename")
     def testLoadMessage(self, mocked_filename):


### PR DESCRIPTION
Large messages in in GOB-Upload weren’t being offloaded because sizeof only returns the size of the reference