### PR TITLE
Hidden attributes added

### DIFF
--- a/gobcore/model/__init__.py
+++ b/gobcore/model/__init__.py
@@ -120,11 +120,11 @@ class GOBModel():
 
     def get_collections(self, catalog_name):
         catalog = self.get_catalog(catalog_name)
-        return catalog['collections'] if 'collections' in catalog else None
+        return catalog['collections'] if catalog and 'collections' in catalog else None
 
     def get_collection(self, catalog_name, collection_name):
         collections = self.get_collections(catalog_name)
-        return collections[collection_name] if collection_name in collections else None
+        return collections[collection_name] if collections and collection_name in collections else None
 
     def get_functional_key_fields(self, catalog_name, collection_name):
         """

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -646,7 +646,8 @@
           "bestaat_uit_buurten": {
             "type": "GOB.ManyReference",
             "description": "De buurten waaruit het object bestaat.",
-            "ref": "gebieden:buurten"
+            "ref": "gebieden:buurten",
+            "hidden": true
           },
           "geometrie": {
             "type": "GOB.Geo.Polygon",
@@ -704,7 +705,8 @@
           "bestaat_uit_buurten": {
             "type": "GOB.ManyReference",
             "description": "De buurten waaruit het object bestaat.",
-            "ref": "gebieden:buurten"
+            "ref": "gebieden:buurten",
+            "hidden": true
           },
           "geometrie": {
             "type": "GOB.Geo.Polygon",


### PR DESCRIPTION
Hidden attributes can be used to skip references in GraphQL and the rest API to prevent circular references. Get collection(s) now returns None if a invalid collection is requested instead of a TypeError