### PR TITLE
Add expiration date

### DIFF
--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -896,6 +896,10 @@
             "type": "GOB.String",
             "description": "Het unieke nummer van het brondocument."
           },
+          "feitelijk_gebruik": {
+            "type": "GOB.JSON",
+            "description": "Feitelijk gebruik van een standplaats."
+          },
           "ligt_in_buurt": {
             "type": "GOB.Reference",
             "ref": "gebieden:buurten",
@@ -963,6 +967,10 @@
           "documentnummer": {
             "type": "GOB.String",
             "description": "Het unieke nummer van het brondocument."
+          },
+          "feitelijk_gebruik": {
+            "type": "GOB.JSON",
+            "description": "Feitelijk gebruik van een ligplaats."
           },
           "ligt_in_buurt": {
             "type": "GOB.Reference",

--- a/gobcore/model/metadata.py
+++ b/gobcore/model/metadata.py
@@ -28,6 +28,7 @@ class FIELD:
     SEQNR = "volgnummer"
     REGISTRATION_DATE = "registratiedatum"
     HASH = "_hash"
+    EXPIRATION_DATE = "_expiration_date"
 
 
 """Description of all fields that are automatically added to each entity"""
@@ -46,6 +47,7 @@ DESCRIPTION = {
     FIELD.SEQNR: "Uniek volgnummer van de toestand van het object.",
     FIELD.REGISTRATION_DATE: "De datum waarop de toestand is geregistreerd.",
     FIELD.HASH: "A hash of the values of all public fields for comparison",
+    FIELD.EXPIRATION_DATE: "Timestamp telling when the entity will be or is expired.",
 }
 
 """Meta data that is registered for every entity"""
@@ -57,6 +59,7 @@ METADATA_COLUMNS = {
         FIELD.DATE_CONFIRMED: "GOB.DateTime",
         FIELD.DATE_MODIFIED: "GOB.DateTime",
         FIELD.DATE_DELETED: "GOB.DateTime",
+        FIELD.EXPIRATION_DATE: "GOB.DateTime",
     },
 
     # These properties will not be made public by the API


### PR DESCRIPTION
Expiration date was added for all entities to be used in when filtering in the API for ‘active’ entities.