### PR TITLE
Heartbeat thread exclusion

### DIFF
--- a/tests/gobcore/status/test_heartbeat.py
+++ b/tests/gobcore/status/test_heartbeat.py
@@ -22,6 +22,7 @@ class MockHeartbeatConnection:
         self.queue = queue
         self.key = key
 
+
 class MockedThread:
     _is_alive = True
 
@@ -38,14 +39,17 @@ def generate_threads(*specs):
             yield MockedThread(*spec)
     return func
 
+
 class TestHeartbeat(unittest.TestCase):
 
     @mock.patch("gobcore.message_broker.message_broker.Connection.connect")
     @mock.patch("gobcore.message_broker.message_broker.Connection.publish")
-    def test_constructor(self, mocked_publish, mocked_connect):
+    @mock.patch("atexit.register")
+    def test_constructor(self, mocked_atexit_register, mocked_publish, mocked_connect):
         connection = MockHeartbeatConnection()
         _heartbeat = Heartbeat(connection, "Myname")
         mocked_connect.assert_not_called()
+        mocked_atexit_register.assert_called()
         self.assertIsNotNone(connection.msg)
 
     @mock.patch("gobcore.message_broker.message_broker.Connection.connect")

--- a/tests/gobcore/status/test_heartbeat.py
+++ b/tests/gobcore/status/test_heartbeat.py
@@ -1,3 +1,4 @@
+import collections
 import unittest
 import mock
 
@@ -5,49 +6,75 @@ from gobcore.message_broker.config import HEARTBEAT_QUEUE, get_queue
 from gobcore.status.heartbeat import Heartbeat
 
 
-class MockHeartbeat:
+class MockHeartbeatConnection:
 
     msg = None
     queue = None
     key = None
 
     def __init__(self):
-        MockHeartbeat.msg = None
-        MockHeartbeat.queue = None
-        MockHeartbeat.key = None
+        self.msg = None
+        self.queue = None
+        self.key = None
 
     def publish(self, queue, key, msg):
-        MockHeartbeat.msg = msg
-        MockHeartbeat.queue = queue
-        MockHeartbeat.key = key
+        self.msg = msg
+        self.queue = queue
+        self.key = key
 
+class MockedThread:
+    _is_alive = True
+
+    def __init__(self, name):
+        self.name = name
+
+    def is_alive(self):
+        return self._is_alive;
+
+
+def generate_threads(*specs):
+    def func():
+        for spec in specs:
+            yield MockedThread(*spec)
+    return func
 
 class TestHeartbeat(unittest.TestCase):
 
-    @mock.patch("atexit.register")
     @mock.patch("gobcore.message_broker.message_broker.Connection.connect")
     @mock.patch("gobcore.message_broker.message_broker.Connection.publish")
-    def test_constructor(self, mocked_publish, mocked_connect, mocked_atexit_register):
-        heartbeat = Heartbeat(MockHeartbeat(), "Myname")
+    def test_constructor(self, mocked_publish, mocked_connect):
+        connection = MockHeartbeatConnection()
+        _heartbeat = Heartbeat(connection, "Myname")
         mocked_connect.assert_not_called()
-        self.assertIsNotNone(MockHeartbeat.msg)
-        mocked_atexit_register.assert_called()
+        self.assertIsNotNone(connection.msg)
 
-    @mock.patch("atexit.register")
     @mock.patch("gobcore.message_broker.message_broker.Connection.connect")
     @mock.patch("gobcore.message_broker.message_broker.Connection.publish")
-    def test_send(self, mocked_publish, mocked_connect, mocked_atexit_register):
-        heartbeat = Heartbeat(MockHeartbeat(), "Myname")
+    def test_send(self, mocked_publish, mocked_connect):
+        connection = MockHeartbeatConnection()
+        heartbeat = Heartbeat(connection, "Myname")
         mocked_publish.reset_mock()
 
         heartbeat.send()
-        self.assertIsNotNone(MockHeartbeat.msg)
-        self.assertEqual(MockHeartbeat.queue["name"], "gob.status.heartbeat")
-        self.assertEqual(MockHeartbeat.key, "HEARTBEAT")
-        self.assertEqual(MockHeartbeat.msg["name"], "Myname")
+        self.assertIsNotNone(connection.msg)
+        self.assertEqual(connection.queue["name"], "gob.status.heartbeat")
+        self.assertEqual(connection.key, "HEARTBEAT")
+        self.assertEqual(connection.msg["name"], "Myname")
+
+    @mock.patch("threading.enumerate", new=generate_threads(["a"]))
+    def test_heartbeat_threads(self):
+        connection = MockHeartbeatConnection()
+        heartbeat = Heartbeat(connection, "Myname")
+        assert len(heartbeat.threads) == 1
+
+    @mock.patch("threading.enumerate", new=generate_threads(["_a"]))
+    def test_heartbeat_no_threads(self):
+        connection = MockHeartbeatConnection()
+        heartbeat = Heartbeat(connection, "Myname")
+        assert len(heartbeat.threads) == 0
 
     def test_progress(self):
-        connection = MockHeartbeat()
+        connection = MockHeartbeatConnection()
         connection.publish = mock.MagicMock()
 
         msg = {


### PR DESCRIPTION
*Problem*: Some threads should not be reported on by heartbeat, because they don't add to the answer on "Is this application still running?".

*Solution*: Exclude threads by adding a filter mechanism. For now a filter that simply excludes thread names that start with an underscore. Example of the use-case in API service:

![image](https://user-images.githubusercontent.com/287022/56954084-3605b980-6b3e-11e9-8b9f-2dad0a2dc3e1.png)
*The second API service only has 2 threads because we were able to exclude the thread prefixed with an underscore.*

*Additional fixes*: 
 * Instantiate HearbeatConnection in tests so we can don't rely on pytest's function scoping.
 * Moved thread enumeration to a new threads property.


