### PR TITLE
Fix microseconds bug

### DIFF
--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -388,8 +388,8 @@ class DateTime(Date):
         if value is not None:
             try:
                 if not isinstance(value, datetime.datetime):
-                    if isinstance(value, str) and len(value) == len('YYYY-MM-DDTHH:MM:SS'):
-                        # Add missing microseconds
+                    if isinstance(value, str) and '.%f' in input_format and len(value) == len('YYYY-MM-DDTHH:MM:SS'):
+                        # Add missing microseconds if needed
                         value += '.000000'
                     value = datetime.datetime.strptime(str(value), input_format)
                 # Transform to internal string format and work around issue: https://bugs.python.org/issue13305


### PR DESCRIPTION
Microseconds were also added when a different input_format was specified. 