### PR TITLE
Added a change to the model, so migrations for events was added

### DIFF
--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -2734,7 +2734,7 @@
         }
       },
       "kadastralesecties": {
-        "version": "0.1",
+        "version": "0.2",
         "abbreviation": "KSE",
         "entity_id": "identificatie",
         "attributes": {
@@ -2746,14 +2746,54 @@
             "type": "GOB.String",
             "description": "Een al­fa­nu­me­rie­ke aan­dui­ding van de ka­das­tra­le sec­tie, deel van de ka­das­tra­le aan­dui­ding van de on­roe­ren­de zaak."
           },
-          "is_onderdeel_van_kadastralegemeente": {
+          "is_onderdeel_van_kadastralegemeentecode": {
             "type": "GOB.Reference",
-            "ref": "brk:kadastralegemeentes",
-            "description": "Een al­fa­nu­me­rie­ke aan­dui­ding van de ka­das­tra­le ge­meen­te, deel van de ka­das­tra­le aan­dui­ding van de on­roe­ren­de zaak. (bv. AS­D02)."
+            "ref": "brk:kadastralegemeentecodes",
+            "description": "Een al­fa­nu­me­rie­ke aan­dui­ding van de ka­das­tra­le ge­meen­tecode, deel van de ka­das­tra­le aan­dui­ding van de on­roe­ren­de zaak. (bv. AS­D02)."
           },
           "geometrie": {
             "type": "GOB.Geo.Geometry",
             "description": "Vorm en lig­ging van de ka­das­tra­le sec­tie in het stel­sel van de Rijks­drie­hoek­me­ting (RD)."
+          }
+        }
+      },
+      "kadastralegemeentecodes": {
+        "version": "0.1",
+        "abbreviation": "KCE",
+        "entity_id": "identificatie",
+        "attributes": {
+          "identificatie": {
+            "type": "GOB.String",
+            "description": "De unie­ke aan­dui­ding van een Ka­das­tra­le gemeentecode."
+          },
+          "is_onderdeel_van_kadastralegemeente": {
+            "type": "GOB.Reference",
+            "ref": "brk:kadastralegemeentes",
+            "description": "De ka­das­tra­le ge­meen­te waar de kadastrale gemeentecode onderdeel van is (bv. Sloten)."
+          },
+          "geometrie": {
+            "type": "GOB.Geo.Geometry",
+            "description": "Vorm en lig­ging van de ka­das­tra­le gemeentecode in het stel­sel van de Rijks­drie­hoek­me­ting (RD)."
+          }
+        }
+      },
+      "kadastralegemeentes": {
+        "version": "0.1",
+        "abbreviation": "KGE",
+        "entity_id": "identificatie",
+        "attributes": {
+          "identificatie": {
+            "type": "GOB.String",
+            "description": "De unie­ke aan­dui­ding van een Ka­das­tra­le ge­meen­te."
+          },
+          "ligt_in_gemeente": {
+            "type": "GOB.Reference",
+            "ref": "brk:gemeentes",
+            "description": "De burgelijke gemeente waarin de kadastrale gemeente ligt."
+          },
+          "geometrie": {
+            "type": "GOB.Geo.Geometry",
+            "description": "Vorm en lig­ging van de ka­das­tra­le gemeente in het stel­sel van de Rijks­drie­hoek­me­ting (RD)."
           }
         }
       }

--- a/gobcore/model/migrations/__init__.py
+++ b/gobcore/model/migrations/__init__.py
@@ -1,0 +1,95 @@
+import json
+import os
+
+from collections import defaultdict
+
+from gobcore.exceptions import GOBException
+
+from gobcore.logging.logger import logger
+
+from gobcore.model import GOBModel
+from gobcore.model.metadata import FIELD
+
+
+class GOBMigrations():
+    _migrations = None
+
+    def __init__(self):
+        if GOBMigrations._migrations is not None:
+            # Migrations already initialised
+            return
+
+        path = os.path.join(os.path.dirname(__file__), 'gobmigrations.json')
+        with open(path) as file:
+            data = json.load(file)
+
+        self._data = data
+        self._model = GOBModel()
+
+        GOBMigrations._migrations = defaultdict(lambda: defaultdict(lambda: defaultdict(None)))
+
+        # Extract migrations for easy access in API
+        self._extract_migrations()
+
+    def _extract_migrations(self):
+        for catalog_name, catalog in self._data.items():
+            for collection_name, collection in catalog.items():
+                for version, migration in collection.items():
+                    # Store the migrations(s) for the catalog - collection - version
+                    self._migrations[catalog_name][collection_name][version] = migration
+
+    def _get_migration(self, catalog_name, collection_name, version):
+        """
+        Get the migration for the specified version in the given catalog - collection
+
+        :param catalog_name:
+        :param collection_name:
+        :param version:
+        :return:
+        """
+        try:
+            return self._migrations[catalog_name][collection_name][version]
+        except KeyError:
+            return None
+
+    def _apply_migration(self, data, migration):
+        for conversion in migration['conversions']:
+            if conversion.get('action') == 'rename':
+                old_key = conversion.get('old_column')
+                new_key = conversion.get('new_column')
+
+                assert all([old_key, new_key]), "Invalid conversion definition"
+
+                # Rename the column
+                data['entity'][new_key] = data['entity'].pop(old_key)
+            else:
+                raise NotImplementedError(f"Conversion {conversion['action']} not implemented")
+
+        # Update the entity version to the new version
+        data['entity'][FIELD.VERSION] = migration['target_version']
+
+        return data
+
+    def migrate_event_data(self, data, catalog_name, collection_name, target_version):
+        """
+        Migrate data to the target version
+
+        :param data:
+        :param catalog_name:
+        :param collection_name:
+        :param target_version:
+        :return:
+        """
+        while data['entity'][FIELD.VERSION] != target_version:
+            current_version = data['entity'][FIELD.VERSION]
+            migration = self._get_migration(catalog_name, collection_name, current_version)
+
+            if not migration:
+                logger.error(f"No migration found for {catalog_name}, {collection_name} {current_version}")
+                raise GOBException(
+                    f"Not able to migrate event for {catalog_name}, {collection_name} to version {target_version}"
+                )
+            # Apply all conversions on the data
+            data = self._apply_migration(data, migration)
+
+        return data

--- a/gobcore/model/migrations/gobmigrations.json
+++ b/gobcore/model/migrations/gobmigrations.json
@@ -1,0 +1,16 @@
+{
+  "brk": {
+    "kadastralesecties": {
+      "0.1": {
+        "target_version": "0.2",
+        "conversions": [
+          {
+            "action": "rename",
+            "old_column": "is_onderdeel_van_kadastralegemeente",
+            "new_column": "is_onderdeel_van_kadastralegemeentecode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/gobcore/model/sa/gob.py
+++ b/gobcore/model/sa/gob.py
@@ -69,10 +69,6 @@ def _derive_models():
 
     for catalog_name, catalog in model.get_catalogs().items():
         for collection_name, collection in model.get_collections(catalog_name).items():
-            if collection['version'] != "0.1":
-                # No migrations defined yet...
-                raise ValueError("Unexpected version, please write a generic migration here or migrate the import")
-
             # "attributes": {
             #     "attribute_name": {
             #         "type": "GOB type name, e.g. GOB.String",
@@ -197,10 +193,6 @@ def _derive_indexes() -> dict:
 
     for catalog_name, catalog in model.get_catalogs().items():
         for collection_name, collection in model.get_collections(catalog_name).items():
-            if collection['version'] != "0.1":
-                # No migrations defined yet...
-                raise ValueError("Unexpected version, please write a generic migration here or migrate the import")
-
             entity = collection['all_fields']
             table_name = model.get_table_name(catalog_name, collection_name)
 

--- a/tests/gobcore/model/migrations/test_migrations.py
+++ b/tests/gobcore/model/migrations/test_migrations.py
@@ -1,0 +1,145 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from gobcore.exceptions import GOBException
+from gobcore.model.migrations import GOBMigrations
+
+
+class TestMigrations(unittest.TestCase):
+
+    def setUp(self):
+        self.migrations = GOBMigrations()
+        self.mock_migration = {
+            'target_version': '0.2',
+            'conversions': [
+                {
+                    'action': 'rename',
+                    'old_column': 'old',
+                    'new_column': 'new'
+                }
+            ]
+        }
+
+    @patch('gobcore.model.migrations.GOBMigrations._extract_migrations')
+    def test_initialize_model_once(self, mock_extract_migrations):
+        # Model has already been initialised, _extract_migrations should not be called again
+        migrations = GOBMigrations()
+        mock_extract_migrations.assert_not_called()
+
+    def test_get_migration(self):
+        # Assert we get a list of relations for a collection
+        self.assertIsInstance(self.migrations._get_migration('brk', 'kadastralesecties', '0.1'), dict)
+
+    def test_get_migration_keyerror(self):
+        # Assert an empty list is returned if no migration is found
+        self.assertEqual(self.migrations._get_migration('catalog', 'collection', '0.1'), None)
+
+    def test_apply_migration(self):
+        # Assert an empty list is returned if no migration is found
+        data = {
+            'entity': {
+                'old': 'value',
+                '_version': '0.1'
+            }
+        }
+
+        expected_data = {
+            'entity': {
+                'new': 'value',
+                '_version': '0.2'
+            }
+        }
+
+        result = self.migrations._apply_migration(data, self.mock_migration)
+
+        self.assertEqual(result, expected_data)
+
+    def test_apply_migration_not_implemented(self):
+        # Assert migration fails for notimplemented action
+        not_implemented_mock_migration = {
+            'target_version': '0.2',
+            'conversions': [
+                {
+                    'action': 'non-existent',
+                }
+            ]
+        }
+
+        data = {}
+
+        with self.assertRaises(NotImplementedError):
+            result = self.migrations._apply_migration(data, not_implemented_mock_migration)
+
+    @patch('gobcore.model.migrations.logger', MagicMock())
+    @patch('gobcore.model.migrations.GOBMigrations._get_migration')
+    def test_migrate_event_data(self, mock_get_migration):
+        mock_get_migration.return_value = self.mock_migration
+
+        data = {
+            'entity': {
+                'old': 'value',
+                '_version': '0.1'
+            }
+        }
+
+        expected_data = {
+            'entity': {
+                'new': 'value',
+                '_version': '0.2'
+            }
+        }
+
+        self.migrations.migrate_event_data(data, 'catalog', 'collection', '0.2')
+
+        self.assertEqual(data, expected_data)
+
+
+    @patch('gobcore.model.migrations.logger', MagicMock())
+    @patch('gobcore.model.migrations.GOBMigrations._get_migration')
+    def test_migrate_event_data_multiple(self, mock_get_migration):
+        mock_migration2 = {
+            'target_version': '0.3',
+            'conversions': [
+                {
+                    'action': 'rename',
+                    'old_column': 'new',
+                    'new_column': 'extra_new'
+                }
+            ]
+        }
+
+        mock_get_migration.side_effect = [self.mock_migration, mock_migration2]
+
+        data = {
+            'entity': {
+                'old': 'value',
+                '_version': '0.1'
+            }
+        }
+
+        expected_data = {
+            'entity': {
+                'extra_new': 'value',
+                '_version': '0.3'
+            }
+        }
+
+        self.migrations.migrate_event_data(data, 'catalog', 'collection', '0.3')
+
+        self.assertEqual(data, expected_data)
+
+    @patch('gobcore.model.migrations.logger')
+    @patch('gobcore.model.migrations.GOBMigrations._get_migration')
+    def test_migrate_event_data_missing_migration(self, mock_get_migration, mock_logger):
+        mock_get_migration.side_effect = [self.mock_migration, None]
+
+        data = {
+            'entity': {
+                'old': 'value',
+                '_version': '0.1'
+            }
+        }
+
+        with self.assertRaises(GOBException):
+            self.migrations.migrate_event_data(data, 'catalog', 'collection', '0.3')
+            mock_logger.assert_called()

--- a/tests/gobcore/model/sa/test_gob.py
+++ b/tests/gobcore/model/sa/test_gob.py
@@ -13,24 +13,3 @@ class TestGob(unittest.TestCase):
         for (name, cls) in models.items():
             m = cls()
             self.assertEqual(str(m), name)
-
-    @patch("gobcore.model.sa.gob.columns_to_model")
-    def test_invalid_version_derive_models(self, mock_columns_to_model):
-        model = GOBModel()
-        model._data['test_catalogue']['collections']['test_entity']['version'] = '0.2'
-
-        with self.assertRaises(ValueError):
-            _derive_models()
-
-        # Reset
-        model._data = None
-
-    def test_invalid_version_derive_indexes(self):
-        model = GOBModel()
-        model._data['test_catalogue']['collections']['test_entity']['version'] = '0.2'
-
-        with self.assertRaises(ValueError):
-            _derive_indexes()
-
-        # Reset
-        model._data = None


### PR DESCRIPTION
The model for kadastralesecties changed while events had already had been imported. Truncating the table and re-applying the events resulted in an error, so the event data had to be changed to fit the new model. A migration file was added which allows for multiple changes on a version. Events will loop try to find the migration if the version of the model is newer and apply the migration to the event data before applying the event to the database.