### PR TITLE
Fix issue in get_source_id when volgnummer is named differently

### DIFF
--- a/gobcore/model/__init__.py
+++ b/gobcore/model/__init__.py
@@ -230,8 +230,14 @@ class GOBModel():
         source_id_field = input_spec['source']['entity_id']
         source_id = str(entity[source_id_field])
         if self.has_states(input_spec['catalogue'], input_spec['entity']):
+            # Volgnummer could be a different field in the source entity than FIELD.SEQNR
+            try:
+                seqnr_field = input_spec['gob_mapping'][FIELD.SEQNR]['source_mapping']
+            except KeyError:
+                seqnr_field = FIELD.SEQNR
+
             # Source id + volgnummer is source id
-            source_id = f"{source_id}.{entity[FIELD.SEQNR]}"
+            source_id = f"{source_id}.{entity[seqnr_field]}"
         return source_id
 
     def get_reference_by_abbreviations(self, catalog_abbreviation, collection_abbreviation):

--- a/tests/gobcore/model/test_model.py
+++ b/tests/gobcore/model/test_model.py
@@ -85,6 +85,29 @@ class TestModel(unittest.TestCase):
         self.assertEqual("idvalue.1", self.model.get_source_id(entity, spec))
         self.model.has_states.assert_called_with('meetbouten', 'meetbouten')
 
+    def test_source_id_states_other_seqnr_field(self):
+        self.model.has_states = MagicMock(return_value=True)
+
+        entity = {
+            'idfield': 'idvalue',
+            'nummervolg': '1'
+        }
+        spec = {
+            'catalogue': 'meetbouten',
+            'entity': 'meetbouten',
+            'source': {
+                'entity_id': 'idfield'
+            },
+            'gob_mapping': {
+                'volgnummer': {
+                    'source_mapping': 'nummervolg'
+                }
+            }
+        }
+
+        self.assertEqual("idvalue.1", self.model.get_source_id(entity, spec))
+        self.model.has_states.assert_called_with('meetbouten', 'meetbouten')
+
     def test_set_api(self):
         model = {}
         self.model._set_api('meetbouten', 'meetbouten', model)
@@ -280,4 +303,3 @@ class TestModel(unittest.TestCase):
         self.assertEqual(expected, model._data)
         mock_print.assert_called_once()
         self.assertTrue(mock_print.call_args[0][0].startswith('ERROR: failed to load schema'))
-


### PR DESCRIPTION
When trying to save the source id in a collection with states the code assumed seqnr is always named ‘volgnummer’. This results in a keyerror when importing data where seqnr is defined differently e.g. ‘VOLGNUMMER’. This fix uses the supplied input_spec to get the correct field with a fallback to ‘volgnummer’.