### PR TITLE
Temporary disable of use NameCompressor for relation tables

### DIFF
--- a/gobcore/model/name_compressor.py
+++ b/gobcore/model/name_compressor.py
@@ -1,13 +1,13 @@
 class NameCompressor():
     _CONVERSIONS = {
-        "aantekening": "ant",
-        "kadastraal": "kad",
-        "appartements": "app",
-        "splitsing": "spl",
-        "ontstaan_uit": "ont",
-        "is_bron_voor": "brn",
-        "betrokken_bij": "btr",
-        "reference": "ref"
+        # "aantekening": "ant",
+        # "kadastraal": "kad",
+        # "appartements": "app",
+        # "splitsing": "spl",
+        # "ontstaan_uit": "ont",
+        # "is_bron_voor": "brn",
+        # "betrokken_bij": "btr",
+        # "reference": "ref"
     }
 
     @classmethod

--- a/tests/gobcore/model/test_name_compressor.py
+++ b/tests/gobcore/model/test_name_compressor.py
@@ -6,6 +6,10 @@ from gobcore.model.name_compressor import NameCompressor
 class TestNameCompressor(unittest.TestCase):
 
     def test_conversions(self):
+        saved_conversions = NameCompressor._CONVERSIONS
+        NameCompressor._CONVERSIONS = {
+            "reference": "ref"
+        }
         names = [
             "",
             "is_bron_voor_aantekening_kadastraal_object",
@@ -25,3 +29,5 @@ class TestNameCompressor(unittest.TestCase):
             conversion = NameCompressor.compress_name(name)
             self.assertTrue(len(conversion) <= len(name))
             self.assertEqual(NameCompressor.uncompress_name(conversion), name)
+
+        NameCompressor._CONVERSIONS = saved_conversions

--- a/tests/gobcore/model/test_relations.py
+++ b/tests/gobcore/model/test_relations.py
@@ -60,15 +60,15 @@ class TestRelations(unittest.TestCase):
         }
 
         # Assert that NameCompressor is used
-        self.assertTrue("reference" in NameCompressor._CONVERSIONS.keys())
+        # self.assertTrue("reference" in NameCompressor._CONVERSIONS.keys())
         name = _get_relation_name(src, dst, "reference")
-        expect = 'cat_col_dst_cat_dst_col__ref_'
+        expect = 'cat_col_dst_cat_dst_col_reference'
         self.assertEqual(name, expect)
 
         model.get_catalog.return_value = src['catalog']
         model.get_collection.return_value = src['collection']
         name = get_relation_name(model, "catalog", "collection", "reference")
-        expect = 'cat_col_cat_col__ref_'
+        expect = 'cat_col_cat_col_reference'
         self.assertEqual(name, expect)
 
     @mock.patch('gobcore.model.relations._get_relation_name')
@@ -106,7 +106,7 @@ class TestRelations(unittest.TestCase):
         self.assertEqual(len(relations['collections'].items()), 1)
 
     def test_split_relation_table_name(self):
-        test_case = "rel_srccat_srccol_dstcat_dstcol__ref_"
+        test_case = "rel_srccat_srccol_dstcat_dstcol_reference"
 
         res = split_relation_table_name(test_case)
         self.assertEqual({


### PR DESCRIPTION
First get migrations working in gob-upload