### PR TITLE
Fix wkpb enhanced views because of relations which are not required

### DIFF
--- a/gobcore/views/wkpb/beperkingen/enhanced.sql
+++ b/gobcore/views/wkpb/beperkingen/enhanced.sql
@@ -1,5 +1,10 @@
 SELECT identificatie
      , beperking
+     , documentnummer
+     , heeft_dossier as dossier
+     , persoonsgegevens_afschermen
+     , orgaan
+     , aard
      , begin_geldigheid
      , eind_geldigheid
 FROM 
@@ -8,6 +13,6 @@ WHERE "status" -> 'code' = '3'
       AND aard -> 'code' <> '3'
       AND (bpg._expiration_date IS NULL 
         OR bpg._expiration_date > NOW()) 
-      AND "_date_deleted" IS NULL
+      AND COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone) > NOW()
 ORDER BY 
     bpg.identificatie

--- a/gobcore/views/wkpb/beperkingen/enhanced.sql
+++ b/gobcore/views/wkpb/beperkingen/enhanced.sql
@@ -11,8 +11,7 @@ FROM
     wkpb_beperkingen bpg 
 WHERE "status" -> 'code' = '3' 
       AND aard -> 'code' <> '3'
-      AND (bpg._expiration_date IS NULL 
-        OR bpg._expiration_date > NOW()) 
       AND COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone) > NOW()
+      AND _date_deleted IS NULL
 ORDER BY 
     bpg.identificatie

--- a/gobcore/views/wkpb/brondocumenten/enhanced.sql
+++ b/gobcore/views/wkpb/brondocumenten/enhanced.sql
@@ -8,8 +8,7 @@ FROM
     wkpb_beperkingen bpg
 WHERE bpg.status -> 'code' = '3'
       AND bpg.aard -> 'code' <> '3'
-      AND (bpg._expiration_date IS NULL 
-        OR bpg._expiration_date > now())
       AND COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone) > NOW()
+      AND _date_deleted IS NULL
 ORDER BY 
     bpg.identificatie

--- a/gobcore/views/wkpb/brondocumenten/enhanced.sql
+++ b/gobcore/views/wkpb/brondocumenten/enhanced.sql
@@ -1,25 +1,15 @@
-SELECT bdt.documentnummer
-	 , dsr.dossier
-	 , bpg.identificatie
-     , bpg.persoonsgegevens_afschermen
-     , bpg.orgaan
-     , bpg.aard
-FROM
-	wkpb_brondocumenten bdt
-INNER JOIN mv_wkpb_dsr_wkpb_bdt_heeft_brondocumenten dsr_bdt
-  ON bdt."_source_id" = dsr_bdt.dst_id
-INNER JOIN wkpb_dossiers dsr
-  ON dsr_bdt.src_id  = dsr."_source_id"
-  AND dsr."_date_deleted" IS NULL
-INNER JOIN mv_wkpb_bpg_wkpb_dsr_heeft_dossier bpg_dsr
-  ON dsr."_source_id" = bpg_dsr.dst_id
-INNER JOIN wkpb_beperkingen bpg
-  ON bpg.identificatie = bpg_dsr.src_id
-  AND bpg."_date_deleted" IS NULL
-WHERE
-	bpg."status" -> 'code' = '3'
-AND bpg.aard -> 'code' <> '3'
-AND (bpg._expiration_date IS NULL
-     OR bpg._expiration_date > NOW())
-ORDER BY
+SELECT bpg.documentnummer,
+    bpg.heeft_dossier as dossier,
+    bpg.identificatie,
+    bpg.persoonsgegevens_afschermen,
+    bpg.orgaan,
+    bpg.aard
+FROM  
+    wkpb_beperkingen bpg
+WHERE bpg.status -> 'code' = '3'
+      AND bpg.aard -> 'code' <> '3'
+      AND (bpg._expiration_date IS NULL 
+        OR bpg._expiration_date > now())
+      AND COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone) > NOW()
+ORDER BY 
     bpg.identificatie


### PR DESCRIPTION
The source Neuron contains data which is more up to date than the source of the brondocumenten (Decos). Because the original view joins to Decos, some required records are removed.
With Karin we decided to only use the wkpb_beperkingen table for the brondocumenten export.

Now that we only use this table the brondocumenten view is the same as wkpb_beperkingen_enhanced, only the selected columns differ. So I added the columns tot the beperkingen view, that way we can remove the brondocumenten view (not immediately because the export won't work anymore).