### PR TITLE
Rel event id index

### DIFF
--- a/gobcore/model/sa/gob.py
+++ b/gobcore/model/sa/gob.py
@@ -181,7 +181,7 @@ def _default_indexes_for_columns(input_columns: list, table_type: str) -> dict:
         (FIELD.EXPIRATION_DATE,),
         (FIELD.APPLICATION,),
         (FIELD.SOURCE_ID,),  # for application of events
-        (f"{FIELD.LAST_EVENT} DESC",)
+        (FIELD.LAST_EVENT,)
     ]
 
     entity_table_indexes = [

--- a/gobcore/model/sa/gob.py
+++ b/gobcore/model/sa/gob.py
@@ -181,7 +181,7 @@ def _default_indexes_for_columns(input_columns: list, table_type: str) -> dict:
         (FIELD.EXPIRATION_DATE,),
         (FIELD.APPLICATION,),
         (FIELD.SOURCE_ID,),  # for application of events
-        (FIELD.LAST_EVENT,)
+        (f"{FIELD.LAST_EVENT} DESC",)
     ]
 
     entity_table_indexes = [

--- a/gobcore/model/sa/gob.py
+++ b/gobcore/model/sa/gob.py
@@ -181,6 +181,7 @@ def _default_indexes_for_columns(input_columns: list, table_type: str) -> dict:
         (FIELD.EXPIRATION_DATE,),
         (FIELD.APPLICATION,),
         (FIELD.SOURCE_ID,),  # for application of events
+        (FIELD.LAST_EVENT,)
     ]
 
     entity_table_indexes = [


### PR DESCRIPTION
Add an index on last_event to improve the performance of the relate queries

Example query part for gebieden-wijken:

**--** Select all entities that are newer than the rows in the relation table
src_entities AS (
    SELECT * FROM gebieden_wijken WHERE _last_event > (
        SELECT COALESCE(MAX(_last_src_event), 0) FROM rel_gbd_wijk_gbd_ggw__ligt_in_ggwgebied
    )
)
,
-- Select all entities that are newer than the rows in the relation table
dst_entities AS (
    SELECT * FROM gebieden_ggwgebieden WHERE _last_event > (
        SELECT COALESCE(MAX(_last_src_event), 0) FROM rel_gbd_wijk_gbd_ggw__ligt_in_ggwgebied
    )
)
,
-- Select max event that has been applied on the entities
max_src_event AS (SELECT MAX(_last_event) _last_event FROM gebieden_wijken)
,
-- Select max event that has been applied on the entities
max_dst_event AS (SELECT MAX(_last_event) _last_event FROM gebieden_ggwgebieden)
