### PR TITLE
Use postgres dialect Array to be able to use sqlalchemy ORM

### DIFF
--- a/gobcore/model/sa/management.py
+++ b/gobcore/model/sa/management.py
@@ -3,7 +3,8 @@
 SQLAlchemy Management Models
 
 """
-from sqlalchemy import Column, DateTime, Integer, JSON, ARRAY, String, Boolean, ForeignKey, Index
+from sqlalchemy import Column, DateTime, Integer, JSON, String, Boolean, ForeignKey, Index
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()


### PR DESCRIPTION
Using the correct postgres dialect gives the option to use contains on an array. This is used in gobworkflow to check the existence of catalogue and collection in the job args column