### PR TITLE
Add relations for test_entity

### DIFF
--- a/gobcore/sources/gobsources.json
+++ b/gobcore/sources/gobsources.json
@@ -1,12 +1,26 @@
 {
-  "REL": {
+  "ADD": {
     "test_catalogue": {
       "test_entity": {
         "reference": {
           "method": "equals",
           "destination_attribute": "string"
         }
-      },
+      }
+    }
+  },
+  "MODIFY1": {
+    "test_catalogue": {
+      "test_entity": {
+        "reference": {
+          "method": "equals",
+          "destination_attribute": "string"
+        }
+      }
+    }
+  },
+  "REL": {
+    "test_catalogue": {
       "rel_test_entity_a": {
         "ref_to_c": {
           "method": "equals",


### PR DESCRIPTION
Test entities are imported using ADD and MODIFY1 as application name
In order to prevent dangling relations the test_entity_ref entities should be imported from the same application