### PR TITLE
Notifications

### DIFF
--- a/gobcore/message_broker/initialise_queues.py
+++ b/gobcore/message_broker/initialise_queues.py
@@ -37,7 +37,7 @@ def _create_vhost(vhost):
     response.raise_for_status()
 
 
-def _create_exchange(channel, exchange, durable):
+def _create_exchange(channel, exchange, durable, exchange_type="topic"):
     """
     Create a RabbitMQ exchange
 
@@ -48,7 +48,7 @@ def _create_exchange(channel, exchange, durable):
     """
     channel.exchange_declare(
         exchange=exchange,
-        exchange_type="topic",
+        exchange_type=exchange_type,
         durable=durable)
 
 

--- a/gobcore/message_broker/initialise_queues.py
+++ b/gobcore/message_broker/initialise_queues.py
@@ -37,7 +37,7 @@ def _create_vhost(vhost):
     response.raise_for_status()
 
 
-def _create_exchange(channel, exchange, durable, exchange_type="topic"):
+def _create_exchange(channel, exchange, durable):
     """
     Create a RabbitMQ exchange
 
@@ -48,7 +48,7 @@ def _create_exchange(channel, exchange, durable, exchange_type="topic"):
     """
     channel.exchange_declare(
         exchange=exchange,
-        exchange_type=exchange_type,
+        exchange_type="topic",
         durable=durable)
 
 

--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -6,7 +6,7 @@ from gobcore.message_broker.async_message_broker import AsyncConnection
 from gobcore.status.heartbeat import Heartbeat, HEARTBEAT_INTERVAL, STATUS_OK, STATUS_START, STATUS_FAIL
 from gobcore.message_broker.config import CONNECTION_PARAMS
 from gobcore.message_broker.initialise_queues import initialize_message_broker
-from gobcore.message_broker.notifications import contains_notifications, send_notifications
+from gobcore.message_broker.notifications import contains_notification, send_notification
 
 CHECK_CONNECTION = 5    # Check connection every n seconds
 
@@ -34,8 +34,8 @@ def _on_message(connection, service, msg):
         # re-raise the exception, further handling is done in the message broker
         raise err
 
-    if contains_notifications(result_msg):
-        send_notifications(result_msg)
+    if contains_notification(result_msg):
+        send_notification(result_msg)
 
     # If a report_queue is defined, report the result message (if any)
     if 'report' in service and result_msg is not None:

--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -6,6 +6,7 @@ from gobcore.message_broker.async_message_broker import AsyncConnection
 from gobcore.status.heartbeat import Heartbeat, HEARTBEAT_INTERVAL, STATUS_OK, STATUS_START, STATUS_FAIL
 from gobcore.message_broker.config import CONNECTION_PARAMS
 from gobcore.message_broker.initialise_queues import initialize_message_broker
+from gobcore.message_broker.notifications import contains_notifications, send_notifications
 
 CHECK_CONNECTION = 5    # Check connection every n seconds
 
@@ -32,6 +33,9 @@ def _on_message(connection, service, msg):
         Heartbeat.progress(connection, service, msg, STATUS_FAIL, str(err))
         # re-raise the exception, further handling is done in the message broker
         raise err
+
+    if contains_notifications(result_msg):
+        send_notifications(result_msg)
 
     # If a report_queue is defined, report the result message (if any)
     if 'report' in service and result_msg is not None:

--- a/gobcore/message_broker/notifications.py
+++ b/gobcore/message_broker/notifications.py
@@ -1,0 +1,158 @@
+import pika
+
+from gobcore.message_broker.config import CONNECTION_PARAMS
+from gobcore.message_broker.utils import to_json
+from gobcore.message_broker.initialise_queues import _create_exchange, _create_queue, _bind_queue
+
+NOTIFY_EXCHANGE = "gob.notify"
+NOTIFICATION_KEY = 'notification'
+NOTIFICATION_HEADER_FIELDS = ['catalogue', 'collection', 'entity', 'version']
+BASE_QUEUE = 'gob.notify'
+
+
+def listen_to_notifications(id):
+    """
+    Listen to notification messages
+    The id is used to create a queue on which notifications will be received for the id
+
+    :param id:
+    :return:
+    """
+    queue = f"{BASE_QUEUE}.{id}"
+    return listen_to_broadcasts(NOTIFY_EXCHANGE, queue)
+
+
+def contains_notifications(result_msg):
+    """
+    Tells wether the message includes any notifications
+
+    :param result_msg:
+    :return:
+    """
+    return result_msg and result_msg.get(NOTIFICATION_KEY)
+
+
+def send_notifications(result_msg):
+    """
+    Send any notifications that are contained in the result msg
+
+    :param result_msg:
+    :return:
+    """
+    # If a notification has been specified then broadcast the notification
+    if contains_notifications(result_msg):
+        header_fields = NOTIFICATION_HEADER_FIELDS
+        notification = {
+            'header': {key: result_msg['header'].get(key) for key in header_fields},
+            **result_msg[NOTIFICATION_KEY]
+        }
+        # Broadcast notification
+        send_broadcast(NOTIFY_EXCHANGE, msg=notification)
+        # Delete when handled
+        del result_msg[NOTIFICATION_KEY]
+
+
+def add_notification(msg, notification):
+    """
+    Include a notification in the message
+
+    :param msg:
+    :param notification:
+    :return:
+    """
+    msg[NOTIFICATION_KEY] = {
+        'type': notification.type,
+        'contents': notification.contents
+    }
+
+
+def get_notification(msg):
+    """
+    Returns an Event object for the given message
+
+    :param msg:
+    :return:
+    """
+    if msg.get('type') == EventNotification.type:
+        return EventNotification.from_msg(msg)
+
+
+class EventNotification():
+
+    type = "events"
+
+    def __init__(self, applied, last_event, header=None):
+        """
+        Initialize an Event Notification
+
+        :param applied: What kind of events have been applied and how many
+        :param last_event: The last eventid after the events have been applied
+        :param header:
+        """
+        self.contents = {
+            'applied': applied,
+            'last_event': last_event
+        }
+        self.header = header
+
+    @classmethod
+    def from_msg(cls, msg):
+        """
+        Construct an Event Notification object from a message
+
+        :param msg:
+        :return:
+        """
+        return cls(**msg['contents'], header=msg['header'])
+
+
+def _create_broadcast_exchange(channel, exchange):
+    """
+    Create the broadcast exchange if it does not yet exist
+
+    :param channel:
+    :param exchange:
+    :return:
+    """
+    _create_exchange(channel, exchange=exchange, durable=False, exchange_type='fanout')
+
+
+def send_broadcast(exchange, msg):
+    """
+    Send a broadcast message on the specified exchange
+
+    :param exchange:
+    :param msg:
+    :return:
+    """
+    with pika.BlockingConnection(CONNECTION_PARAMS) as connection:
+        channel = connection.channel()
+
+        _create_broadcast_exchange(channel, exchange)
+
+        # Convert the message to json
+        json_msg = to_json(msg)
+
+        # Broadcast the message as a non-persistent message on the queue
+        channel.basic_publish(
+            exchange=exchange,
+            routing_key='',
+            body=json_msg
+        )
+
+
+def listen_to_broadcasts(exchange, queue):
+    """
+    Listen to broadcast messages on the specified exchange and queue
+
+    :param exchange:
+    :param queue:
+    :return:
+    """
+    with pika.BlockingConnection(CONNECTION_PARAMS) as connection:
+        channel = connection.channel()
+
+        _create_broadcast_exchange(channel, exchange)
+        _create_queue(channel=channel, queue=queue, durable=False)
+        _bind_queue(channel=channel, exchange=exchange, queue=queue, key='')
+    return queue

--- a/gobcore/message_broker/notifications.py
+++ b/gobcore/message_broker/notifications.py
@@ -27,7 +27,7 @@ def listen_to_notifications(id, notification_type=None):
     :return:
     """
     queue = f"{NOTIFY_BASE_QUEUE}.{id}"
-    return listen_to_broadcasts(NOTIFY_EXCHANGE, queue, notification_type)
+    return listen_to_broadcasts(NOTIFY_EXCHANGE, queue, notification_type or '')
 
 
 def contains_notifications(result_msg):
@@ -169,5 +169,5 @@ def listen_to_broadcasts(exchange, queue, notification_type=None):
         _create_broadcast_exchange(channel=channel, exchange=exchange)
         _create_queue(channel=channel, queue=queue, durable=True)
         # Bind to the queue and listen to messages of the specifief type
-        _bind_queue(channel=channel, exchange=exchange, queue=queue, key=notification_type)
+        _bind_queue(channel=channel, exchange=exchange, queue=queue, key=notification_type or '')
     return queue

--- a/gobcore/message_broker/notifications.py
+++ b/gobcore/message_broker/notifications.py
@@ -4,10 +4,15 @@ from gobcore.message_broker.config import CONNECTION_PARAMS
 from gobcore.message_broker.utils import to_json
 from gobcore.message_broker.initialise_queues import _create_exchange, _create_queue, _bind_queue
 
+# Use a dedicated exchange for notifications
 NOTIFY_EXCHANGE = "gob.notify"
+# Each queue in the notification exchange starts with 'gob.notify'
+NOTIFY_BASE_QUEUE = 'gob.notify'
+# Notifications can be included in a message with the 'notification' key
 NOTIFICATION_KEY = 'notification'
-NOTIFICATION_HEADER_FIELDS = ['catalogue', 'collection', 'entity', 'version']
-BASE_QUEUE = 'gob.notify'
+# Notification messages copy a selection of the original header fields
+NOTIFICATION_HEADER_FIELDS = [
+    'process_id', 'jobid', 'stepid', 'source', 'catalogue', 'collection', 'entity', 'version']
 
 
 def listen_to_notifications(id):
@@ -18,7 +23,7 @@ def listen_to_notifications(id):
     :param id:
     :return:
     """
-    queue = f"{BASE_QUEUE}.{id}"
+    queue = f"{NOTIFY_BASE_QUEUE}.{id}"
     return listen_to_broadcasts(NOTIFY_EXCHANGE, queue)
 
 

--- a/gobcore/message_broker/notifications.py
+++ b/gobcore/message_broker/notifications.py
@@ -119,7 +119,7 @@ def _create_broadcast_exchange(channel, exchange):
     :param exchange:
     :return:
     """
-    _create_exchange(channel, exchange=exchange, durable=False, exchange_type='fanout')
+    _create_exchange(channel, exchange=exchange, durable=True, exchange_type='fanout')
 
 
 def send_broadcast(exchange, msg):
@@ -142,6 +142,9 @@ def send_broadcast(exchange, msg):
         channel.basic_publish(
             exchange=exchange,
             routing_key='',
+            properties=pika.BasicProperties(
+                delivery_mode=2  # Make messages persistent
+            ),
             body=json_msg
         )
 
@@ -158,6 +161,6 @@ def listen_to_broadcasts(exchange, queue):
         channel = connection.channel()
 
         _create_broadcast_exchange(channel, exchange)
-        _create_queue(channel=channel, queue=queue, durable=False)
+        _create_queue(channel=channel, queue=queue, durable=True)
         _bind_queue(channel=channel, exchange=exchange, queue=queue, key='')
     return queue

--- a/gobcore/workflow/start_workflow.py
+++ b/gobcore/workflow/start_workflow.py
@@ -1,0 +1,37 @@
+import json
+import pika
+
+from gobcore.message_broker.config import CONNECTION_PARAMS, WORKFLOW_EXCHANGE, WORKFLOW_REQUEST_KEY
+
+
+def start_workflow(workflow, arguments):
+    """
+    Start a workflow for the given specs
+
+    Puts a message on the bus to request execution of the give workflow
+
+    :param workflow_spec:
+    :return:
+    """
+
+    # Simple version, store all arguments in the header
+    msg = {
+        'header': arguments,
+        'workflow': workflow
+    }
+
+    with pika.BlockingConnection(CONNECTION_PARAMS) as connection:
+        channel = connection.channel()
+
+        # Convert the message to json
+        json_msg = json.dumps(msg)
+
+        # Publish a workflow-request message on the workflow-exchange for the given workflow
+        channel.basic_publish(
+            exchange=WORKFLOW_EXCHANGE,
+            routing_key=WORKFLOW_REQUEST_KEY,
+            properties=pika.BasicProperties(
+                delivery_mode=2  # Make messages persistent
+            ),
+            body=json_msg
+        )

--- a/tests/gobcore/message_broker/test_messagedriven_service.py
+++ b/tests/gobcore/message_broker/test_messagedriven_service.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, call
 from tests.gobcore import fixtures
 
 from gobcore.message_broker.async_message_broker import AsyncConnection
-from gobcore.message_broker.config import WORKFLOW_EXCHANGE, CONNECTION_PARAMS
+from gobcore.message_broker.config import CONNECTION_PARAMS
 from gobcore.message_broker import messagedriven_service
 from gobcore.message_broker.messagedriven_service import MessagedrivenService, _on_message, STATUS_FAIL
 
@@ -24,13 +24,13 @@ def mock_get_on_message(service):
 
 class TestMessageDrivenServiceFunctions(unittest.TestCase):
 
-    @mock.patch("gobcore.message_broker.messagedriven_service.contains_notifications")
-    @mock.patch("gobcore.message_broker.messagedriven_service.send_notifications")
-    def test_on_message(self, mock_send_notifications, mock_contains_notifications):
+    @mock.patch("gobcore.message_broker.messagedriven_service.contains_notification")
+    @mock.patch("gobcore.message_broker.messagedriven_service.send_notification")
+    def test_on_message(self, mock_send_notification, mock_contains_notification):
 
         global return_message
 
-        mock_contains_notifications = True
+        mock_contains_notification = True
 
         # setup mocks and fixtures
         mocked_handler = mock.Mock(wraps=handler)
@@ -58,7 +58,7 @@ class TestMessageDrivenServiceFunctions(unittest.TestCase):
             # The return message should be published on the return queue
             mocked_publish.assert_called_with(return_queue['exchange'], return_queue['key'], return_message)
 
-        mock_send_notifications.assert_called_with(return_message)
+        mock_send_notification.assert_called_with(return_message)
 
     @mock.patch("gobcore.message_broker.messagedriven_service.Heartbeat")
     def test_on_message_fail(self, mock_heartbeat):

--- a/tests/gobcore/message_broker/test_messagedriven_service.py
+++ b/tests/gobcore/message_broker/test_messagedriven_service.py
@@ -23,9 +23,14 @@ def mock_get_on_message(service):
 
 
 class TestMessageDrivenServiceFunctions(unittest.TestCase):
-    def test_on_message(self):
+
+    @mock.patch("gobcore.message_broker.messagedriven_service.contains_notifications")
+    @mock.patch("gobcore.message_broker.messagedriven_service.send_notifications")
+    def test_on_message(self, mock_send_notifications, mock_contains_notifications):
 
         global return_message
+
+        mock_contains_notifications = True
 
         # setup mocks and fixtures
         mocked_handler = mock.Mock(wraps=handler)
@@ -52,6 +57,8 @@ class TestMessageDrivenServiceFunctions(unittest.TestCase):
 
             # The return message should be published on the return queue
             mocked_publish.assert_called_with(return_queue['exchange'], return_queue['key'], return_message)
+
+        mock_send_notifications.assert_called_with(return_message)
 
     @mock.patch("gobcore.message_broker.messagedriven_service.Heartbeat")
     def test_on_message_fail(self, mock_heartbeat):

--- a/tests/gobcore/message_broker/test_notifications.py
+++ b/tests/gobcore/message_broker/test_notifications.py
@@ -3,14 +3,13 @@ from mock import patch
 from unittest.mock import MagicMock, call
 
 from gobcore.message_broker.notifications import listen_to_notifications,\
-    contains_notifications,\
-    send_notifications,\
+    contains_notification,\
+    send_notification,\
     add_notification,\
     get_notification,\
     EventNotification,\
-    _create_broadcast_exchange,\
-    send_broadcast,\
-    listen_to_broadcasts
+    _send_notification,\
+    _listen_to_notifications
 
 @patch("gobcore.message_broker.notifications.NOTIFY_EXCHANGE", 'notification exchange')
 @patch("gobcore.message_broker.notifications.NOTIFY_BASE_QUEUE", 'base queue')
@@ -18,37 +17,37 @@ from gobcore.message_broker.notifications import listen_to_notifications,\
 @patch("gobcore.message_broker.notifications.NOTIFICATION_HEADER_FIELDS", ['a', 'b'])
 class TestNotifications(TestCase):
 
-    @patch("gobcore.message_broker.notifications.listen_to_broadcasts")
-    def test_listen_to_notifications(self, mock_listen_to_broadcasts):
+    @patch("gobcore.message_broker.notifications._listen_to_notifications")
+    def test_listen_to_notifications(self, mock_listen_to_notifications):
         result = listen_to_notifications('any id')
-        mock_listen_to_broadcasts.assert_called_with('notification exchange', 'base queue.any id', '')
-        self.assertEqual(result, mock_listen_to_broadcasts.return_value)
+        mock_listen_to_notifications.assert_called_with('notification exchange', 'base queue.any id', '')
+        self.assertEqual(result, mock_listen_to_notifications.return_value)
 
         result = listen_to_notifications('any id', 'any type')
-        mock_listen_to_broadcasts.assert_called_with('notification exchange', 'base queue.any id', 'any type')
+        mock_listen_to_notifications.assert_called_with('notification exchange', 'base queue.any id', 'any type')
 
     def test_contains_notifications(self):
-        result = contains_notifications(None)
+        result = contains_notification(None)
         self.assertFalse(result, None)
 
-        result = contains_notifications({})
+        result = contains_notification({})
         self.assertFalse(result, {})
 
-        result = contains_notifications({'any key': 'any value'})
+        result = contains_notification({'any key': 'any value'})
         self.assertFalse(result, None)
 
-        result = contains_notifications({'notification key': 'any notification'})
+        result = contains_notification({'notification key': 'any notification'})
         self.assertTrue(result, 'any notification')
 
-    @patch("gobcore.message_broker.notifications.send_broadcast")
-    def test_send_notifications(self, mock_send_broadcast):
-        send_notifications({})
-        mock_send_broadcast.assert_not_called()
+    @patch("gobcore.message_broker.notifications._send_notification")
+    def test_send_notifications(self, mock_send_notification):
+        send_notification({})
+        mock_send_notification.assert_not_called()
 
-        send_notifications({'header': {'a': 1, 'c': 3}, 'notification key': {'type': "any type", 'x': 1, 'y': 2}})
-        mock_send_broadcast.assert_called_with('notification exchange',
-                                               notification_type='any type',
-                                               msg={
+        send_notification({'header': {'a': 1, 'c': 3}, 'notification key': {'type': "any type", 'x': 1, 'y': 2}})
+        mock_send_notification.assert_called_with('notification exchange',
+                                                  notification_type='any type',
+                                                  msg={
                                                    'header': {'a': 1, 'b': None},
                                                    'type': "any type",
                                                    'x': 1,
@@ -82,23 +81,16 @@ class TestNotifications(TestCase):
         self.assertEqual(result.header, 'any header')
         self.assertEqual(result.contents, {'applied': 'any applied', 'last_event': 'any last_event'})
 
-    @patch("gobcore.message_broker.notifications._create_exchange")
-    def test__create_broadcast_exchange(self, mock_create_exchange):
-        _create_broadcast_exchange('any channel', 'any exchange')
-        mock_create_exchange.assert_called_with(channel='any channel',
-                                                durable=True,
-                                                exchange='any exchange')
-
     @patch("gobcore.message_broker.notifications.pika.BasicProperties")
     @patch("gobcore.message_broker.notifications.pika.BlockingConnection")
-    @patch("gobcore.message_broker.notifications._create_broadcast_exchange")
-    def test_send_broadcast(self, mock_create_broadcast_exchange, mock_blocking_connection, mock_basic_properties):
+    @patch("gobcore.message_broker.notifications._create_exchange")
+    def test_send_broadcast(self, mock_create_exchange, mock_blocking_connection, mock_basic_properties):
         mock_connection = MagicMock()
         mock_channel = MagicMock()
         mock_blocking_connection.return_value.__enter__.return_value = mock_connection
         mock_connection.channel.return_value = mock_channel
-        send_broadcast('any exchange', 'any type', {})
-        mock_create_broadcast_exchange.assert_called_with(channel=mock_channel, exchange='any exchange')
+        _send_notification('any exchange', 'any type', {})
+        mock_create_exchange.assert_called_with(channel=mock_channel, exchange='any exchange', durable=True)
         mock_channel.basic_publish.assert_called_with(
             body='{}',
             exchange='any exchange',
@@ -108,16 +100,16 @@ class TestNotifications(TestCase):
             routing_key='any type')
 
     @patch("gobcore.message_broker.notifications.pika.BlockingConnection")
-    @patch("gobcore.message_broker.notifications._create_broadcast_exchange")
+    @patch("gobcore.message_broker.notifications._create_exchange")
     @patch("gobcore.message_broker.notifications._create_queue")
     @patch("gobcore.message_broker.notifications._bind_queue")
-    def test_listen_to_broadcasts(self, mock_bind_queue, mock_create_queue, mock_create_broadcast_exchange, mock_blocking_connection):
+    def test_listen_to_broadcasts(self, mock_bind_queue, mock_create_queue, mock_create_exchange, mock_blocking_connection):
         mock_connection = MagicMock()
         mock_channel = MagicMock()
         mock_blocking_connection.return_value.__enter__.return_value = mock_connection
         mock_connection.channel.return_value = mock_channel
-        result = listen_to_broadcasts('any exchange', 'any queue')
-        mock_create_broadcast_exchange.assert_called_with(channel=mock_channel, exchange='any exchange')
+        result = _listen_to_notifications('any exchange', 'any queue')
+        mock_create_exchange.assert_called_with(channel=mock_channel, exchange='any exchange', durable=True)
         mock_create_queue.assert_called_with(channel=mock_channel, queue='any queue', durable=True)
         mock_bind_queue.assert_called_with(channel=mock_channel, exchange='any exchange', queue='any queue', key='')
         self.assertEqual(result, 'any queue')

--- a/tests/gobcore/message_broker/test_notifications.py
+++ b/tests/gobcore/message_broker/test_notifications.py
@@ -1,0 +1,116 @@
+import mock
+from unittest import TestCase
+from mock import patch
+from unittest.mock import MagicMock, call
+
+from tests.gobcore import fixtures
+
+from gobcore.message_broker.notifications import listen_to_notifications,\
+    contains_notifications,\
+    send_notifications,\
+    add_notification,\
+    get_notification,\
+    EventNotification,\
+    _create_broadcast_exchange,\
+    send_broadcast,\
+    listen_to_broadcasts
+
+@patch("gobcore.message_broker.notifications.NOTIFY_EXCHANGE", 'notification exchange')
+@patch("gobcore.message_broker.notifications.NOTIFICATION_KEY", 'notification key')
+@patch("gobcore.message_broker.notifications.NOTIFICATION_HEADER_FIELDS", ['a', 'b'])
+@patch("gobcore.message_broker.notifications.BASE_QUEUE", 'base queue')
+class TestNotifications(TestCase):
+
+    @patch("gobcore.message_broker.notifications.listen_to_broadcasts")
+    def test_listen_to_notifications(self, mock_listen_to_broadcasts):
+        result = listen_to_notifications('any id')
+        mock_listen_to_broadcasts.assert_called_with('notification exchange', 'base queue.any id')
+        self.assertEqual(result, mock_listen_to_broadcasts.return_value)
+
+    def test_contains_notifications(self):
+        result = contains_notifications(None)
+        self.assertFalse(result, None)
+
+        result = contains_notifications({})
+        self.assertFalse(result, {})
+
+        result = contains_notifications({'any key': 'any value'})
+        self.assertFalse(result, None)
+
+        result = contains_notifications({'notification key': 'any notification'})
+        self.assertTrue(result, 'any notification')
+
+    @patch("gobcore.message_broker.notifications.send_broadcast")
+    def test_send_notifications(self, mock_send_broadcast):
+        send_notifications({})
+        mock_send_broadcast.assert_not_called()
+
+        send_notifications({'header': {'a': 1, 'c': 3}, 'notification key': {'x': 1, 'y': 2}})
+        mock_send_broadcast.assert_called_with('notification exchange',
+                                               msg={
+                                                   'header': {'a': 1, 'b': None},
+                                                   'x': 1,
+                                                   'y': 2
+                                               })
+
+    def test_add_notification(self):
+        notification = EventNotification('any applied', 'any last_event')
+        msg = {}
+        add_notification(msg, notification)
+        expect = {
+            'notification key': {
+                'type': 'events',
+                'contents': {
+                    'applied': 'any applied',
+                    'last_event': 'any last_event'
+                }
+            }}
+        self.assertEqual(msg, expect)
+
+    def test_get_notification(self):
+        result = get_notification({})
+        self.assertIsNone(result)
+
+        result = get_notification({
+            'header': 'any header',
+            'type': 'events',
+            'contents': {'applied': 'any applied', 'last_event': 'any last_event'}
+        })
+        self.assertEqual(result.type, 'events')
+        self.assertEqual(result.header, 'any header')
+        self.assertEqual(result.contents, {'applied': 'any applied', 'last_event': 'any last_event'})
+
+    @patch("gobcore.message_broker.notifications._create_exchange")
+    def test__create_broadcast_exchange(self, mock_create_exchange):
+        _create_broadcast_exchange('any channel', 'any exchange')
+        mock_create_exchange.assert_called_with('any channel',
+                                                durable=False,
+                                                exchange='any exchange',
+                                                exchange_type='fanout')
+
+    @patch("gobcore.message_broker.notifications.pika.BlockingConnection")
+    @patch("gobcore.message_broker.notifications._create_broadcast_exchange")
+    def test_send_broadcast(self, mock_create_broadcast_exchange, mock_blocking_connection):
+        mock_connection = MagicMock()
+        mock_channel = MagicMock()
+        mock_blocking_connection.return_value.__enter__.return_value = mock_connection
+        mock_connection.channel.return_value = mock_channel
+        send_broadcast('any exchange', {})
+        mock_create_broadcast_exchange.assert_called_with(mock_channel, 'any exchange')
+        mock_channel.basic_publish.assert_called_with(body='{}', exchange='any exchange', routing_key='')
+
+    @patch("gobcore.message_broker.notifications.pika.BlockingConnection")
+    @patch("gobcore.message_broker.notifications._create_broadcast_exchange")
+    @patch("gobcore.message_broker.notifications._create_queue")
+    @patch("gobcore.message_broker.notifications._bind_queue")
+    def test_listen_to_broadcasts(self, mock_bind_queue, mock_create_queue, mock_create_broadcast_exchange, mock_blocking_connection):
+        mock_connection = MagicMock()
+        mock_channel = MagicMock()
+        mock_blocking_connection.return_value.__enter__.return_value = mock_connection
+        mock_connection.channel.return_value = mock_channel
+        result = listen_to_broadcasts('any exchange', 'any queue')
+        mock_create_broadcast_exchange.assert_called_with(mock_channel, 'any exchange')
+        mock_create_queue.assert_called_with(channel=mock_channel, queue='any queue', durable=False)
+        mock_bind_queue.assert_called_with(channel=mock_channel, exchange='any exchange', queue='any queue', key='')
+        self.assertEqual(result, 'any queue')
+

--- a/tests/gobcore/message_broker/test_notifications.py
+++ b/tests/gobcore/message_broker/test_notifications.py
@@ -16,9 +16,9 @@ from gobcore.message_broker.notifications import listen_to_notifications,\
     listen_to_broadcasts
 
 @patch("gobcore.message_broker.notifications.NOTIFY_EXCHANGE", 'notification exchange')
+@patch("gobcore.message_broker.notifications.NOTIFY_BASE_QUEUE", 'base queue')
 @patch("gobcore.message_broker.notifications.NOTIFICATION_KEY", 'notification key')
 @patch("gobcore.message_broker.notifications.NOTIFICATION_HEADER_FIELDS", ['a', 'b'])
-@patch("gobcore.message_broker.notifications.BASE_QUEUE", 'base queue')
 class TestNotifications(TestCase):
 
     @patch("gobcore.message_broker.notifications.listen_to_broadcasts")

--- a/tests/gobcore/message_broker/test_notifications.py
+++ b/tests/gobcore/message_broker/test_notifications.py
@@ -21,7 +21,7 @@ class TestNotifications(TestCase):
     @patch("gobcore.message_broker.notifications.listen_to_broadcasts")
     def test_listen_to_notifications(self, mock_listen_to_broadcasts):
         result = listen_to_notifications('any id')
-        mock_listen_to_broadcasts.assert_called_with('notification exchange', 'base queue.any id', None)
+        mock_listen_to_broadcasts.assert_called_with('notification exchange', 'base queue.any id', '')
         self.assertEqual(result, mock_listen_to_broadcasts.return_value)
 
         result = listen_to_notifications('any id', 'any type')
@@ -119,6 +119,6 @@ class TestNotifications(TestCase):
         result = listen_to_broadcasts('any exchange', 'any queue')
         mock_create_broadcast_exchange.assert_called_with(channel=mock_channel, exchange='any exchange')
         mock_create_queue.assert_called_with(channel=mock_channel, queue='any queue', durable=True)
-        mock_bind_queue.assert_called_with(channel=mock_channel, exchange='any exchange', queue='any queue', key=None)
+        mock_bind_queue.assert_called_with(channel=mock_channel, exchange='any exchange', queue='any queue', key='')
         self.assertEqual(result, 'any queue')
 

--- a/tests/gobcore/workflow/test_start_workflow.py
+++ b/tests/gobcore/workflow/test_start_workflow.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from gobcore.workflow.start_workflow import start_workflow
+
+@patch("gobcore.workflow.start_workflow.WORKFLOW_EXCHANGE", 'workflow exchange')
+@patch("gobcore.workflow.start_workflow.WORKFLOW_REQUEST_KEY", 'workflow request key')
+class TestStartWorkflow(TestCase):
+
+    @patch("gobcore.workflow.start_workflow.pika.BasicProperties")
+    @patch("gobcore.workflow.start_workflow.pika.BlockingConnection")
+    def test_start_workflow(self, mock_blocking_connection, mock_basic_properties):
+        mock_connection = MagicMock()
+        mock_channel = MagicMock()
+        mock_blocking_connection.return_value.__enter__.return_value = mock_connection
+        mock_connection.channel.return_value = mock_channel
+        start_workflow('any workflow', 'any arguments')
+        mock_channel.basic_publish.assert_called_with(
+            body='{"header": "any arguments", "workflow": "any workflow"}',
+            exchange='workflow exchange',
+            properties=mock_basic_properties(
+                delivery_mode=2  # Make messages persistent
+            ),
+            routing_key='workflow request key')


### PR DESCRIPTION
GOB jobs can add a notification to a result message. This notification will be recognized by the message driven service. A notification message is then put on the bus on a broadcast channel. Arbitrary processes might subscribe to this notification channel and all processes will receive all broadcasts.

Broadcasting events (like the application of new events) can be used to run processes in parallel and to attach processes to the basic GOB workflow. Examples are the update of cstore tables, analysis database, Iris user interface, connector with Data Services or the distribution of notifications. This all while leaving the basic GOB Workflow untouched. Error prone time scheduling can be replaced by event driven workflows with an extra advantage that these workflows run in parallel instead of sequentially.

Example; when the events have been applied in GOB the updates of the cstore tables, analysis database en a future synchronization with Data Services can all run event based (no unnecessary delays) and in parallel.

The newly implemented custom workflows of e2e tests can be used to run any workflow when an broadcast is received.