### PR TITLE
QA update stores the string value of any "betwijfelde waarde"

### DIFF
--- a/gobcore/quality/quality_update.py
+++ b/gobcore/quality/quality_update.py
@@ -61,7 +61,7 @@ class QualityUpdate():
             'attribuut': issue.attribute,
             'identificatie': issue.entity_id,
             'volgnummer': getattr(issue, FIELD.SEQNR),
-            'betwijfelde_waarde': issue.value,
+            'betwijfelde_waarde': str(issue.value),
             'onderbouwing': issue.get_explanation(),
             'voorgestelde_waarde': None
         }

--- a/tests/gobcore/quality/test_quality_update.py
+++ b/tests/gobcore/quality/test_quality_update.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from gobcore.quality.quality_update import QualityUpdate
+from gobcore.typesystem.gob_types import Decimal
+
+class TestQualityUpdate(TestCase):
+
+    def test_get_contents(self):
+        qa = QualityUpdate([])
+
+        mock_issue = MagicMock()
+        for value in 1, True, 2.5, "any value", Decimal(1.5):
+            mock_issue.value = value
+            contents = qa.get_contents(mock_issue)
+            self.assertEqual(contents['betwijfelde_waarde'], str(value))


### PR DESCRIPTION
A "betwijfelde waarde" can be of any type.
When the type is a Decimal for instance the JSON serialisation would fail in the upload process
By converting the value to a string the string representation is stored and any serialisation errors are prevented