### PR TITLE
Also update QA catalog when no issues are present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amsterdam/docker_python:latest
+FROM amsterdam/python:3.7-buster
 MAINTAINER datapunt@amsterdam.nl
 
 # Install gobworkflow in /app folder

--- a/gobcore/quality/issue.py
+++ b/gobcore/quality/issue.py
@@ -148,7 +148,7 @@ def log_issue(logger: Logger, level: QA_LEVEL, issue: Issue) -> None:
 
 def is_functional_process(process):
     """
-    A functional process is to import, comparem, relate of check relations
+    A functional process is to import, compare, relate of check relations
     Other process steps like apply are technical and issues should not be logged for those steps
 
     :param process:

--- a/gobcore/quality/quality_update.py
+++ b/gobcore/quality/quality_update.py
@@ -6,6 +6,8 @@ from gobcore.model.quality import QUALITY_CATALOG, get_entity_name
 
 class QualityUpdate():
 
+    CATALOG = QUALITY_CATALOG
+
     def __init__(self, issues):
         self.issues = issues if isinstance(issues, list) else [issues]
         self.source = None

--- a/tests/gobcore/message_broker/test_messagedriven_service.py
+++ b/tests/gobcore/message_broker/test_messagedriven_service.py
@@ -26,7 +26,8 @@ class TestMessageDrivenServiceFunctions(unittest.TestCase):
 
     @mock.patch("gobcore.message_broker.messagedriven_service.contains_notification")
     @mock.patch("gobcore.message_broker.messagedriven_service.send_notification")
-    def test_on_message(self, mock_send_notification, mock_contains_notification):
+    @mock.patch("gobcore.message_broker.messagedriven_service.process_issues")
+    def test_on_message(self, mock_process_issues, mock_send_notification, mock_contains_notification):
 
         global return_message
 
@@ -58,6 +59,7 @@ class TestMessageDrivenServiceFunctions(unittest.TestCase):
             # The return message should be published on the return queue
             mocked_publish.assert_called_with(return_queue['exchange'], return_queue['key'], return_message)
 
+        mock_process_issues.assert_called_with(return_message)
         mock_send_notification.assert_called_with(return_message)
 
     @mock.patch("gobcore.message_broker.messagedriven_service.Heartbeat")


### PR DESCRIPTION
This solves the case that when all issues have been solved the open issues should be deleted
Formerly empty issues were skipped which resulted in issues remain open.
This is because deletion is derived from the fact that nothing is imported.

In order to prevent 'overflowing' workflow with useless QA-update jobs
only the functional jobs are processed