### PR TITLE
Change type of QA volgnummer from string to int

### DIFF
--- a/gobcore/model/quality.py
+++ b/gobcore/model/quality.py
@@ -28,7 +28,7 @@ def _get_qa(catalog, collection):
                 "description": "Unieke identificatie van het object waarop de melding van toepassing op is"
             },
             "volgnummer": {
-                "type": "GOB.String",
+                "type": "GOB.Integer",
                 "description": "Volgnummer van het object waarop de melding van toepassing is"
             },
             "begin_geldigheid": {


### PR DESCRIPTION
The type was string, which used to be the old type for volgnummer
It should be integer to comply with the other catalogs