### PR TITLE
Retry workflow

### DIFF
--- a/gobcore/quality/issue.py
+++ b/gobcore/quality/issue.py
@@ -257,9 +257,11 @@ def process_issues(msg):
     if quality_update.catalogue == QualityUpdate.CATALOG:
         return
 
+    # Start the workflow, allow retries when an identical workflow is already running for max_retry_time seconds
     workflow = {
         'workflow_name': "import",
-        'step_name': "update_model"
+        'step_name': "update_model",
+        'retry_time': 10 * 60   # retry for max 10 minutes
     }
     wf_msg = quality_update.get_msg(msg)
     start_workflow(workflow, wf_msg)

--- a/gobcore/workflow/start_workflow.py
+++ b/gobcore/workflow/start_workflow.py
@@ -1,7 +1,7 @@
 import json
 import pika
 
-from gobcore.message_broker.config import CONNECTION_PARAMS, WORKFLOW_EXCHANGE, WORKFLOW_REQUEST_KEY
+from gobcore.message_broker.config import CONNECTION_PARAMS, WORKFLOW_EXCHANGE, WORKFLOW_QUEUE, WORKFLOW_REQUEST_KEY
 
 
 def start_workflow(workflow, arguments):
@@ -38,3 +38,59 @@ def start_workflow(workflow, arguments):
             ),
             body=json_msg
         )
+
+
+def retry_workflow(msg):
+    """
+    Retry to start the given workflow msg
+
+    The message is sent to a queue that delays the message for a specified interval
+    The message is resent until the remaining retry time that is specified in the message is less or equal to zero
+
+    :param msg: workflow message
+    :return:
+    """
+    SINGLE_RETRY_TIME = 1 * 60  # Retry every 1 minute
+    RETRY_TIME = 'retry_time'
+
+    workflow = msg['workflow']
+
+    # Check if any retry time is left
+    remaining_retry_time = workflow.get(RETRY_TIME, 0)
+    if remaining_retry_time <= 0:
+        # No time left, do not send the workflow message
+        return False
+
+    # reduce remaining retry time
+    remaining_retry_time -= SINGLE_RETRY_TIME
+    workflow[RETRY_TIME] = remaining_retry_time
+
+    # Log retry
+    print(f"Retry workflow, {remaining_retry_time} time left", workflow)
+
+    with pika.BlockingConnection(CONNECTION_PARAMS) as connection:
+        # Create a delay queue if it does not yet exist (idempotent action)
+        delay_queue = f"{WORKFLOW_QUEUE}_delay"
+        delay_channel = connection.channel()
+        delay_channel.queue_declare(queue=delay_queue,
+                                    durable=True,
+                                    arguments={
+                                        'x-dead-letter-exchange': WORKFLOW_EXCHANGE,
+                                        'x-dead-letter-routing-key': WORKFLOW_REQUEST_KEY
+                                    })
+
+        # Convert the message to json
+        json_msg = json.dumps(msg)
+
+        # Publish a delayed workflow-request message
+        delay_channel.basic_publish(
+            exchange='',
+            routing_key=delay_queue,
+            properties=pika.BasicProperties(
+                delivery_mode=2,  # Make messages persistent
+                expiration=str(SINGLE_RETRY_TIME * 1000)  # msecs
+            ),
+            body=json_msg
+        )
+
+    return True

--- a/tests/gobcore/quality/test_issue.py
+++ b/tests/gobcore/quality/test_issue.py
@@ -298,7 +298,8 @@ class TestIssue(TestCase):
         process_issues(msg)
         mock_start_workflow.assert_called_with({
             'workflow_name': "import",
-            'step_name': "update_model"
+            'step_name': "update_model",
+            'retry_time': ANY
         }, {
             'header': {
                 'catalogue': 'qa',


### PR DESCRIPTION
A workflow can start with an already running workflow
In order to prevent rejected jobs for automated workflows an optional retry parameter is introduced

The conflict can arise when QA updates are processed for two attributes of an identical entity
Each attribute runs a dedicated update process on the same entity
The specification of a retry can prevent any collisions