### PR TITLE
Reset Oracle fetchcount to 100 rows

### DIFF
--- a/gobcore/datastore/oracle.py
+++ b/gobcore/datastore/oracle.py
@@ -70,7 +70,7 @@ class OracleDatastore(SqlDatastore):
 
         :return: a list of data
         """
-        FETCH_PER = 1000  # Fetch contents in chunks, default chunk size = 100
+        FETCH_PER = 100  # Fetch contents in chunks, default chunk size = 100
 
         cursor = self.connection.cursor()
         cursor.arraysize = FETCH_PER


### PR DESCRIPTION
The optimal value seems to be around the default fetchcount. Increasing or decreasing did not improve perfomance.
A value > 500 seems to have a negative impact on the performance.