### PR TITLE
Fix bug in logger

### DIFF
--- a/gobcore/logging/logger.py
+++ b/gobcore/logging/logger.py
@@ -87,7 +87,8 @@ class Logger:
     LOGFORMAT = "%(asctime)s %(name)-12s %(levelname)-8s %(message)s"
     LOGLEVEL = logging.INFO
 
-    _SAVE_LOGS = ['warning', 'error']  # Save these messages to report at end of msg handling
+    # Save these messages to report at end of msg handling
+    _SAVE_LOGS = ['warning', 'error', 'data_warning', 'data_error']
 
     MAX_SIZE = 10000
     SHORT_MESSAGE_SIZE = 1000
@@ -124,10 +125,10 @@ class Logger:
             self.messages[level].append(msg)
 
     def get_warnings(self):
-        return self.messages['warning']
+        return self.messages['warning'] + self.messages['data_warning']
 
     def get_errors(self):
-        return self.messages['error']
+        return self.messages['error'] + self.messages['data_error']
 
     def _log(self, level, msg, kwargs=None):
         """

--- a/tests/gobcore/logging/test_logger.py
+++ b/tests/gobcore/logging/test_logger.py
@@ -24,13 +24,17 @@ class TestLogger(TestCase):
 
     def test_get_warnings(self):
         logger = Logger()
-        logger.messages['warning'] = 'warning messages'
-        self.assertEqual('warning messages', logger.get_warnings())
+        logger.messages['warning'] = ['warning messages']
+        self.assertEqual(['warning messages'], logger.get_warnings())
+        logger.messages['data_warning'] = ['data warning messages']
+        self.assertEqual(['warning messages', 'data warning messages'], logger.get_warnings())
 
     def test_get_errors(self):
         logger = Logger()
-        logger.messages['error'] = 'error messages'
-        self.assertEqual('error messages', logger.get_errors())
+        logger.messages['error'] = ['error messages']
+        self.assertEqual(['error messages'], logger.get_errors())
+        logger.messages['data_error'] = ['data error messages']
+        self.assertEqual(['error messages', 'data error messages'], logger.get_errors())
 
     def test_log(self):
         mock_level_logger = MagicMock()


### PR DESCRIPTION
Data errors were no longer recognised as errors.
Errors are fatal and should stop any further processing.
For data errors this was no longer the case and this has been corrected.