### PR TITLE
Issue creation failed on illegal validity

### DIFF
--- a/gobcore/quality/issue.py
+++ b/gobcore/quality/issue.py
@@ -126,10 +126,14 @@ class Issue():
         :return:
         """
         value = entity.get(attribute)
-        if isinstance(value, str):
-            value = parser.parse(value)
-        elif isinstance(value, datetime.date):
-            value = datetime.datetime.combine(value, datetime.datetime.min.time())
+        try:
+            if isinstance(value, str):
+                value = parser.parse(value)
+            elif isinstance(value, datetime.date):
+                value = datetime.datetime.combine(value, datetime.datetime.min.time())
+        except ValueError:
+            # Validity is erroneous; set value to None
+            value = None
         return self._get_value({attribute: value}, attribute)
 
     def _get_value(self, entity: dict, attribute: str):

--- a/tests/gobcore/quality/test_issue.py
+++ b/tests/gobcore/quality/test_issue.py
@@ -317,6 +317,21 @@ class TestIssue(TestCase):
             }
         })
 
+    def test_get_validity(self):
+        entity = {
+            'id': 'any id',
+            'validity': '2020-05-22'
+        }
+        issue = Issue({'id': 'any_check'}, entity, 'id', 'validity')
+        self.assertEqual(issue._get_validity(entity, 'validity'), '2020-05-22T00:00:00')
+
+        entity['validity'] = datetime.date(year=1020, month=5, day=22)
+        self.assertEqual(issue._get_validity(entity, 'validity'), '1020-05-22T00:00:00')
+
+        # Conversion fails, set to None
+        entity['validity'] = 'non date'
+        self.assertEqual(issue._get_validity(entity, 'validity'), None)
+
     def test_state_attributes(self):
         entity = {
             'id': 'any id',


### PR DESCRIPTION
On creation of an Issue the begin- and eindgeldigheid are interpreted.
If any of these values is in a wrong format a ValueError was thrown

The ValueError is now catched and the value is set to None
in case of any "wrong" validiy value