### PR TITLE
Allow for callables as queue in service definitions to prevent callin…

### DIFF
--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -80,7 +80,7 @@ class MessagedrivenService:
     MessagedrivenService(SERVICEDEFINITION).start()
 
     """
-    def __init__(self, services, name, params=None):
+    def __init__(self, services: dict, name: str, params=None):
         self.services = services
         self.name = name
         self.params = params or {}
@@ -107,6 +107,12 @@ class MessagedrivenService:
             sys.exit(1)
 
         print("Succesfully initialized message broker")
+
+        # Call all queue functions that need setting up after the message broker is initialized
+        # For example, in a SERVICEDEFINITION, you'll find 'queue': lambda: listen_to_notifications(....)
+        for service_id, service in self.services.items():
+            if callable(service['queue']):
+                service['queue'] = service['queue']()
 
     def _start_threads(self, queues: list):
         for queue in queues:


### PR DESCRIPTION
…g of listen_to_notifications function on module load


In SERVICEDEFINITION were queues that listened to notifications defined as

'queue': listen_to_notifications(....)

This caused listen_to_notifications to be called at the moment the module was loaded. Changed this to 'queue': lambda: listen_to_notifications(..) so that the message driven service has control over when those queues are initialised.