### PR TITLE
Threaded services per service

### DIFF
--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -9,7 +9,8 @@ from gobcore.message_broker.initialise_queues import initialize_message_broker
 from gobcore.message_broker.notifications import contains_notification, send_notification
 from gobcore.quality.issue import process_issues
 
-CHECK_CONNECTION = 5    # Check connection every n seconds
+CHECK_CONNECTION = 5                # Check connection every n seconds
+RUNS_IN_OWN_THREAD = "own_thread"   # Service that runs in a separate thread
 
 # Assure that heartbeats are sent at every HEARTBEAT_INTERVAL
 assert(HEARTBEAT_INTERVAL % CHECK_CONNECTION == 0)
@@ -160,7 +161,7 @@ class MessagedrivenService:
 
     def start(self):
         asynchronous_queues = [service['queue'] for service in self.services.values()
-                               if self.thread_per_service or service.get('own_thread')]
+                               if self.thread_per_service or service.get(RUNS_IN_OWN_THREAD)]
         synchronous_queues = [service['queue'] for service in self.services.values()
                               if not service['queue'] in asynchronous_queues]
 

--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -159,12 +159,16 @@ class MessagedrivenService:
             print(f"Queue connection for {id} stopped.")
 
     def start(self):
-        queues = [service['queue'] for service in self.services.values()]
+        asynchronous_queues = [service['queue'] for service in self.services.values()
+                               if self.thread_per_service or service.get('own_thread')]
+        synchronous_queues = [service['queue'] for service in self.services.values()
+                              if not service['queue'] in asynchronous_queues]
 
-        if self.thread_per_service:
-            self._start_threads(queues)
-        else:
-            self._start_thread(queues)
+        if asynchronous_queues:
+            self._start_threads(asynchronous_queues)
+
+        if synchronous_queues:
+            self._start_thread(synchronous_queues)
 
         self._heartbeat_loop()
 


### PR DESCRIPTION
Currently services are started in separate threads or in one thread.
This PR allows separate services to be configured to run in a separate thread om a per-service basis.

The purpose of this change is to minimize delay in the handling of notifications.
A notification is published on the bus and should be picked up without waiting for other services in the same module to have finished.
The result of the handling of a notification is normally the start of a workflow.
By minimizing the delay in handling of notifications the workflows are started as soon as possible.
