### PR TITLE
BAGExtract: Get id's to track mutations for from last full import file.

### DIFF
--- a/gobcore/datastore/bag_extract.py
+++ b/gobcore/datastore/bag_extract.py
@@ -50,109 +50,15 @@ def _extract_nested_zip(zip_file, nested_zip_files: List[str], destination_dir: 
                 _extract_nested_zip(nested_zip_file_data, nested_zip_files[1:], destination_dir)
 
 
-class BagExtractDatastore(Datastore):
+class ElementFormatter:
     ns_pattern = re.compile(r'{.*}')
-    namespaces = {
-        # We could extract namespaces from the file, but this way we're sure they won't change in the source.
-        'DatatypenNEN3610': 'www.kadaster.nl/schemas/lvbag/imbag/datatypennen3610/v20200601',
-        'Objecten': 'www.kadaster.nl/schemas/lvbag/imbag/objecten/v20200601',
-        'gml': 'http://www.opengis.net/gml/3.2',
-        'Historie': 'www.kadaster.nl/schemas/lvbag/imbag/historie/v20200601',
-        'Objecten-ref': 'www.kadaster.nl/schemas/lvbag/imbag/objecten-ref/v20200601',
-        'ml': 'http://www.kadaster.nl/schemas/mutatielevering-generiek/1.0',
-        'mlm': 'http://www.kadaster.nl/schemas/lvbag/extract-deelbestand-mutaties-lvc/v20200601',
-        'nen5825': 'www.kadaster.nl/schemas/lvbag/imbag/nen5825/v20200601',
-        'KenmerkInOnderzoek': 'www.kadaster.nl/schemas/lvbag/imbag/kenmerkinonderzoek/v20200601',
-        'selecties-extract': 'http://www.kadaster.nl/schemas/lvbag/extract-selecties/v20200601',
-        'sl-bag-extract': 'http://www.kadaster.nl/schemas/lvbag/extract-deelbestand-lvc/v20200601',
-        'sl': 'http://www.kadaster.nl/schemas/standlevering-generiek/1.0',
-        'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-        'xs': 'http://www.w3.org/2001/XMLSchema',
-    }
+    gml_namespace = "http://www.opengis.net/gml/3.2"
 
-    def __init__(self, connection_config: dict, read_config: dict = None):
-        super().__init__(connection_config, read_config)
+    def __init__(self, element):
+        self.element = element
 
-        self.tmp_dir = TemporaryDirectory()
-        self.files = []
-
-        self._check_config()
-
-        xml_object = self.read_config.get('xml_object')
-        self.full_xml_path = f"./sl:standBestand/sl:stand/sl-bag-extract:bagObject/Objecten:{xml_object}"
-        self.mutation_xml_paths = [
-            # Ordering matters. First 'toevoeging', then 'wijziging'
-            f"./ml:mutatieBericht/ml:mutatieGroep/ml:toevoeging/ml:wordt/mlm:bagObject/Objecten:{xml_object}",
-            f"./ml:mutatieBericht/ml:mutatieGroep/ml:wijziging/ml:wordt/mlm:bagObject/Objecten:{xml_object}",
-        ]
-
-        self.mode = self.read_config['mode']
-        assert isinstance(self.mode, ImportMode), "mode should be of type ImportMode"
-
-    def _check_config(self):
-        for key in ('object_type', 'xml_object', 'mode', 'gemeentes', 'download_location'):
-            if not self.read_config.get(key):
-                raise GOBException(f"Missing {key} in read_config")
-
-    def _extract_full_file(self, file_location: str):
-        filename = file_location.split('/')[-1]
-        match = re.match(r'^BAGGEM(\d{4})L-(\d{8}).zip$', filename)
-
-        if not match:
-            raise GOBException(f"Unexpected filename format: {filename}")
-
-        gemeente = match.group(1)
-        datestr = match.group(2)
-
-        _extract_nested_zip(file_location, [
-            f"{gemeente}GEM{datestr}.zip",
-            f"{gemeente}{self.read_config['object_type']}{datestr}.zip",
-        ], self.tmp_dir.name)
-
-        return [os.path.join(self.tmp_dir.name, f)
-                for f in sorted(os.listdir(self.tmp_dir.name)) if f.endswith('.xml')]
-
-    def _extract_mutations_file(self, file_location: str):
-        filename = file_location.split('/')[-1]
-        match = re.match(r'^BAGNLDM-(\d{8}-\d{8}).zip$', filename)
-
-        if not match:
-            raise GOBException(f"Unexpected filename format: {filename}")
-
-        daterange = match.group(1)
-        _extract_nested_zip(file_location, [
-            f"9999MUT{daterange}.zip",
-        ], self.tmp_dir.name)
-
-        return [os.path.join(self.tmp_dir.name, f)
-                for f in sorted(os.listdir(self.tmp_dir.name)) if f.endswith('.xml')]
-
-    def connect(self):
-        file_location = self._download_file(self.read_config['download_location'])
-
-        if self.mode == ImportMode.FULL:
-            self.files = self._extract_full_file(file_location)
-        else:
-            self.files = self._extract_mutations_file(file_location)
-
-    def disconnect(self):
-        pass  # pragma: no cover
-
-    def _download_file(self, file_location: str):
-        """Downloads source file and returns file location
-
-        :return:
-        """
-        fname = file_location.split('/')[-1]
-        download_location = os.path.join(self.tmp_dir.name, fname)
-
-        resp = requests.get(file_location)
-        resp.raise_for_status()
-
-        with open(download_location, 'wb') as f:
-            f.write(resp.content)
-
-        return download_location
+    def get_dict(self):
+        return self._flatten_dict(self._element_to_dict(self.element))
 
     def _gml_to_wkt(self, elm):
         gml_str = ET.tostring(elm).decode('utf-8')
@@ -235,7 +141,7 @@ class BagExtractDatastore(Datastore):
         """
         childs = list(element)
 
-        if len(childs) == 1 and self.namespaces['gml'] in childs[0].tag:
+        if len(childs) == 1 and self.gml_namespace in childs[0].tag:
             return self._gml_to_wkt(childs[0])
         elif childs:
             child_dicts = defaultdict(list)
@@ -248,10 +154,142 @@ class BagExtractDatastore(Datastore):
         else:
             return element.text.strip()
 
+
+class BagExtractDatastore(Datastore):
+    namespaces = {
+        # We could extract namespaces from the file, but this way we're sure they won't change in the source.
+        'DatatypenNEN3610': 'www.kadaster.nl/schemas/lvbag/imbag/datatypennen3610/v20200601',
+        'Objecten': 'www.kadaster.nl/schemas/lvbag/imbag/objecten/v20200601',
+        'gml': 'http://www.opengis.net/gml/3.2',
+        'Historie': 'www.kadaster.nl/schemas/lvbag/imbag/historie/v20200601',
+        'Objecten-ref': 'www.kadaster.nl/schemas/lvbag/imbag/objecten-ref/v20200601',
+        'ml': 'http://www.kadaster.nl/schemas/mutatielevering-generiek/1.0',
+        'mlm': 'http://www.kadaster.nl/schemas/lvbag/extract-deelbestand-mutaties-lvc/v20200601',
+        'nen5825': 'www.kadaster.nl/schemas/lvbag/imbag/nen5825/v20200601',
+        'KenmerkInOnderzoek': 'www.kadaster.nl/schemas/lvbag/imbag/kenmerkinonderzoek/v20200601',
+        'selecties-extract': 'http://www.kadaster.nl/schemas/lvbag/extract-selecties/v20200601',
+        'sl-bag-extract': 'http://www.kadaster.nl/schemas/lvbag/extract-deelbestand-lvc/v20200601',
+        'sl': 'http://www.kadaster.nl/schemas/standlevering-generiek/1.0',
+        'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+        'xs': 'http://www.w3.org/2001/XMLSchema',
+    }
+
+    id_path = "Objecten:identificatie"
+    seqnr_path = "Objecten:voorkomen/Historie:Voorkomen/Historie:voorkomenidentificatie"
+
+    def __init__(self, connection_config: dict, read_config: dict = None):
+        super().__init__(connection_config, read_config)
+
+        self.tmp_dir = TemporaryDirectory()
+        self.files = []
+        self.ids = None
+
+        self._check_config()
+
+        xml_object = self.read_config.get('xml_object')
+        self.full_xml_path = f"./sl:standBestand/sl:stand/sl-bag-extract:bagObject/Objecten:{xml_object}"
+        self.mutation_xml_paths = [
+            # Ordering matters. First 'toevoeging', then 'wijziging'
+            f"./ml:mutatieBericht/ml:mutatieGroep/ml:toevoeging/ml:wordt/mlm:bagObject/Objecten:{xml_object}",
+            f"./ml:mutatieBericht/ml:mutatieGroep/ml:wijziging/ml:wordt/mlm:bagObject/Objecten:{xml_object}",
+        ]
+
+        self.mode = self.read_config['mode']
+        assert isinstance(self.mode, ImportMode), "mode should be of type ImportMode"
+
+    def _check_config(self):
+        for key in ('object_type', 'xml_object', 'mode', 'gemeentes', 'download_location'):
+            if not self.read_config.get(key):
+                raise GOBException(f"Missing {key} in read_config")
+
+        if self.read_config['mode'] == ImportMode.MUTATIONS:
+            if not self.read_config.get("last_full_download_location"):
+                raise GOBException(f"Missing last_full_download_location in read_config")
+
+    def _extract_full_file(self, file_location: str):
+        filename = file_location.split('/')[-1]
+        match = re.match(r'^BAGGEM(\d{4})L-(\d{8}).zip$', filename)
+
+        if not match:
+            raise GOBException(f"Unexpected filename format: {filename}")
+
+        gemeente = match.group(1)
+        datestr = match.group(2)
+
+        dst_dir = os.path.join(self.tmp_dir.name, 'full')
+        _extract_nested_zip(file_location, [
+            f"{gemeente}GEM{datestr}.zip",
+            f"{gemeente}{self.read_config['object_type']}{datestr}.zip",
+        ], dst_dir)
+
+        return [os.path.join(dst_dir, f)
+                for f in sorted(os.listdir(dst_dir)) if f.endswith('.xml')]
+
+    def _extract_mutations_file(self, file_location: str):
+        filename = file_location.split('/')[-1]
+        match = re.match(r'^BAGNLDM-(\d{8}-\d{8}).zip$', filename)
+
+        if not match:
+            raise GOBException(f"Unexpected filename format: {filename}")
+
+        daterange = match.group(1)
+        dst_dir = os.path.join(self.tmp_dir.name, 'mutations')
+        _extract_nested_zip(file_location, [
+            f"9999MUT{daterange}.zip",
+        ], dst_dir)
+
+        return [os.path.join(dst_dir, f)
+                for f in sorted(os.listdir(dst_dir)) if f.endswith('.xml')]
+
+    def _get_mutation_ids(self):
+        """
+
+        :return:
+        """
+        last_full_location = self._download_file(self.read_config['last_full_download_location'])
+        full_files = self._extract_full_file(last_full_location)
+
+        ids = []
+        for file in full_files:
+            tree = ET.parse(file)
+            for elm in tree.getroot().iterfind(f"{self.full_xml_path}/{self.id_path}", self.namespaces):
+                ids.append(elm.text)
+        return ids
+
+    def connect(self):
+        file_location = self._download_file(self.read_config['download_location'])
+
+        if self.mode == ImportMode.FULL:
+            self.files = self._extract_full_file(file_location)
+        else:
+            self.ids = self._get_mutation_ids()
+            self.files = self._extract_mutations_file(file_location)
+
+    def disconnect(self):
+        pass  # pragma: no cover
+
+    def _download_file(self, file_location: str):
+        """Downloads source file and returns file location
+
+        :return:
+        """
+        fname = file_location.split('/')[-1]
+        download_location = os.path.join(self.tmp_dir.name, fname)
+
+        resp = requests.get(file_location)
+        resp.raise_for_status()
+
+        with open(download_location, 'wb') as f:
+            f.write(resp.content)
+
+        return download_location
+
     def _get_elements_full(self, xmlroot):
         yield from xmlroot.iterfind(self.full_xml_path, self.namespaces)
 
     def _get_elements_mutations(self, xmlroot):
+        assert self.ids is not None, "self.ids should be initialised"
+
         gemeentes = self.read_config.get('gemeentes', [])
 
         # Collect mutations in dict. Only keep last mutation for an object.
@@ -260,14 +298,13 @@ class BagExtractDatastore(Datastore):
         for path in self.mutation_xml_paths:
 
             for element in xmlroot.iterfind(path, self.namespaces):
-                identificatie = element.find("./Objecten:identificatie", self.namespaces)
+                identificatie = element.find(f"./{self.id_path}", self.namespaces)
 
-                # Filter by gemeentecode prefix (first 4 digits)
-                if identificatie is not None and identificatie.text.strip()[:4] in gemeentes:
-                    volgnummer = element.find(
-                        "./Objecten:voorkomen/Historie:Voorkomen/Historie:voorkomenidentificatie",
-                        self.namespaces
-                    )
+                # Filter by id, or by gemeentecode prefix (first 4 digits)
+                if identificatie is not None and (
+                        identificatie in self.ids or identificatie.text.strip()[:4] in gemeentes
+                ):
+                    volgnummer = element.find(f"./{self.seqnr_path}", self.namespaces)
 
                     object_id = identificatie.text.strip() \
                         if volgnummer is None \
@@ -282,9 +319,6 @@ class BagExtractDatastore(Datastore):
 
         for file in self.files:
             tree = ET.parse(file)
-            root = tree.getroot()
 
-            elements = get_elements_fn(root)
-
-            for element in elements:
-                yield self._flatten_dict(self._element_to_dict(element))
+            for element in get_elements_fn(tree.getroot()):
+                yield ElementFormatter(element).get_dict()

--- a/tests/gobcore/datastore/bag_extract_fixtures/mutations.xml
+++ b/tests/gobcore/datastore/bag_extract_fixtures/mutations.xml
@@ -35,7 +35,7 @@
                         <Objecten:Verblijfsobject>
                             <Objecten:heeftAlsHoofdadres>
                                 <Objecten-ref:NummeraanduidingRef domein="NL.IMBAG.Nummeraanduiding">
-                                    0457200000199376
+                                    0458200000199376
                                     This object should be ignored, because there's a newer modification for this same
                                     object.
                                 </Objecten-ref:NummeraanduidingRef>
@@ -85,7 +85,7 @@
                         <Objecten:Verblijfsobject>
                             <Objecten:heeftAlsHoofdadres>
                                 <Objecten-ref:NummeraanduidingRef domein="NL.IMBAG.Nummeraanduiding">
-                                    0457200000199376
+                                    0458200000199376
                                     This object should be ignored, because there's a newer modification for this same
                                     object.
                                 </Objecten-ref:NummeraanduidingRef>
@@ -135,7 +135,7 @@
                         <Objecten:Verblijfsobject>
                             <Objecten:heeftAlsHoofdadres>
                                 <Objecten-ref:NummeraanduidingRef domein="NL.IMBAG.Nummeraanduiding">
-                                    0457200000199376
+                                    0458200000199376
                                 </Objecten-ref:NummeraanduidingRef>
                             </Objecten:heeftAlsHoofdadres>
                             <Objecten:voorkomen>
@@ -182,7 +182,7 @@
                         <Objecten:Verblijfsobject>
                             <Objecten:heeftAlsHoofdadres>
                                 <Objecten-ref:NummeraanduidingRef domein="NL.IMBAG.Nummeraanduiding">
-                                    0457200000199376
+                                    0458200000199376
                                 </Objecten-ref:NummeraanduidingRef>
                             </Objecten:heeftAlsHoofdadres>
                             <Objecten:voorkomen>


### PR DESCRIPTION
Extract ElementFormatter to its own class to clean up the BAGExtractDatastore class

Sorry, should have do the refactoring in a different commit.

The actual changes aren't that big: it's mainly the changes in _get_mutation_ids and _get_elements_mutations. The first method is a new method to determine the id's to import from the mutations file. The _get_elements_mutations has an extra check on this list of ID's.