### PR TITLE
Objectstore xls read empty string as `null`

### DIFF
--- a/gobcore/datastore/objectstore.py
+++ b/gobcore/datastore/objectstore.py
@@ -207,7 +207,7 @@ class ObjectDatastore(Datastore, ListEnabledDatastore, PutEnabledDatastore, Dele
         :return: The list of non-empty rows
         """
         io_obj = io.BytesIO(obj)
-        excel = pandas.read_excel(io=io_obj, keep_default_na=False, dtype=str)
+        excel = pandas.read_excel(io=io_obj, keep_default_na=False, dtype=str, na_values='')
 
         return self._yield_rows(excel.iterrows(), file_info, config)
 


### PR DESCRIPTION
Empty strings need to be converted to (pandas) null values. Import sees `""` as a valid value and can't parse it as a date.