### PR TITLE
BREAKING - Refactor - remove all initialisations of GOBModel from GOB-Core and expect GOBModel as parameter in functions.

### DIFF
--- a/gobcore/events/import_events.py
+++ b/gobcore/events/import_events.py
@@ -25,7 +25,7 @@ class ImportEvent(metaclass=ABCMeta):
     name = "event"
     is_add_new = False
     timestamp_field = None  # Each event is timestamped
-    gob_model = GOBModel()
+    gob_model = None
     skip = ["_entity_source_id", "_last_event"]
 
     @classmethod
@@ -68,6 +68,9 @@ class ImportEvent(metaclass=ABCMeta):
         self._data = data  # Data for internal used. Can be modified
         self._metadata = metadata
         self.last_event = self._data.pop("_last_event", None)
+
+        if ImportEvent.gob_model is None:
+            ImportEvent.gob_model = GOBModel()
 
         self._model = self.gob_model.get_collection(self._metadata.catalogue, self._metadata.entity)
 

--- a/gobcore/model/__init__.py
+++ b/gobcore/model/__init__.py
@@ -2,14 +2,12 @@ import os
 import json
 
 from gobcore.exceptions import GOBException
-from gobcore.model.events import EVENTS, EVENTS_DESCRIPTION
 from gobcore.model.metadata import FIELD
 from gobcore.model.metadata import STATE_FIELDS
 from gobcore.model.metadata import PRIVATE_META_FIELDS, PUBLIC_META_FIELDS, FIXED_FIELDS
 from gobcore.model.relations import get_relations, get_inverse_relations
 from gobcore.model.quality import QUALITY_CATALOG, get_quality_assurances
 from gobcore.model.schema import load_schema, SchemaException
-
 
 
 class NotInModelException(Exception):

--- a/gobcore/model/events.py
+++ b/gobcore/model/events.py
@@ -1,0 +1,28 @@
+EVENTS_DESCRIPTION = {
+    "eventid": "Unique identification of the event, numbered sequentially",
+    "timestamp": "Datetime when the event as created",
+    "catalogue": "The catalogue in which the entity resides",
+    "entity": "The entity to which the event need to be applied",
+    "tid": "The tid (combination _id and volgnummer, if applicable) of the entity this event refers to",
+    "version": "The version of the entity model",
+    "action": "Add, change, delete or confirm",
+    "source": "The functional source of the entity, e.g. AMSBI",  # Deprecated. Remove later
+    "application": "The technical source of the entity, e.g. DIVA",
+    "source_id": "The id of the entity in the source",  # Deprecated. Remove later
+    "contents": "A json object that holds the contents for the action, the full entity for an Add",
+}
+
+EVENTS = {
+    "eventid": "GOB.PKInteger",
+    "timestamp": "GOB.DateTime",
+    "catalogue": "GOB.String",
+    "entity": "GOB.String",
+    "tid": "GOB.String",
+    "version": "GOB.String",
+    "action": "GOB.String",
+    "source": "GOB.String",  # Deprecated. Remove later
+    "application": "GOB.String",
+    "source_id": "GOB.String",  # Deprecated. Remove later
+    "contents": "GOB.JSON",
+}
+

--- a/gobcore/model/events.py
+++ b/gobcore/model/events.py
@@ -25,4 +25,3 @@ EVENTS = {
     "source_id": "GOB.String",  # Deprecated. Remove later
     "contents": "GOB.JSON",
 }
-

--- a/gobcore/model/sa/gob.py
+++ b/gobcore/model/sa/gob.py
@@ -3,21 +3,16 @@
 SQLAlchemy GOB Models
 
 """
-import hashlib
-
-import re
-
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.schema import UniqueConstraint, ForeignKeyConstraint
 
 # Import data definitions
-from gobcore.model import GOBModel, EVENTS, EVENTS_DESCRIPTION
+from gobcore.model.events import EVENTS, EVENTS_DESCRIPTION
 from gobcore.model.metadata import FIELD
 from gobcore.model.metadata import columns_to_fields
 from gobcore.model.relations import split_relation_table_name
 from gobcore.model.name_compressor import NameCompressor
-from gobcore.sources import GOBSources
-from gobcore.typesystem import get_gob_type, is_gob_geo_type, is_gob_json_type
+from gobcore.typesystem import get_gob_type
 
 TABLE_TYPE_RELATION = 'relation_table'
 TABLE_TYPE_ENTITY = 'entity_table'
@@ -64,7 +59,7 @@ def _create_model_type(table_name, columns, has_states, table_args):
     })
 
 
-def columns_to_model(catalog_name, table_name, columns, has_states=False, constraint_columns=None):
+def columns_to_model(model, catalog_name, table_name, columns, has_states=False, constraint_columns=None):
     """Create a model out of table_name and GOB column specification
 
     :param table_name: name of the table
@@ -72,7 +67,6 @@ def columns_to_model(catalog_name, table_name, columns, has_states=False, constr
     :param has_states:
     :return: Model class
     """
-    model = GOBModel()
     # Convert columns to SQLAlchemy Columns
     columns = {column_name: get_column(column_name, column_spec) for column_name, column_spec in columns.items()}
 
@@ -142,19 +136,21 @@ def columns_to_model(catalog_name, table_name, columns, has_states=False, constr
     return _create_model_type(table_name, columns, has_states, table_args)
 
 
-def _derive_models():
+def get_sqlalchemy_models(model):
     """Derive Models from GOB model specification
 
     :return: None
     """
 
-    model = GOBModel()
+    if model.__class__.sqlalchemy_models:
+        return model.__class__.sqlalchemy_models
+
     models = {
         # e.g. "meetbouten_rollagen": <BASE>
     }
 
     # Start with events
-    columns_to_model(None, "events", columns_to_fields(EVENTS, EVENTS_DESCRIPTION), constraint_columns=["eventid"])
+    columns_to_model(model, None, "events", columns_to_fields(EVENTS, EVENTS_DESCRIPTION), constraint_columns=["eventid"])
 
     for catalog_name, catalog in model.get_catalogs().items():
         for collection_name, collection in model.get_collections(catalog_name).items():
@@ -168,178 +164,8 @@ def _derive_models():
 
             # the GOB model for the specified entity
             table_name = model.get_table_name(catalog_name, collection_name)
-            models[table_name] = columns_to_model(catalog_name, table_name, collection['all_fields'],
+            models[table_name] = columns_to_model(model, catalog_name, table_name, collection['all_fields'],
                                                   has_states=collection.get('has_states', False))
 
+    model.__class__.sqlalchemy_models = models
     return models
-
-
-def _remove_leading_underscore(s: str):
-    return re.sub(r'^_', '', s)
-
-
-def _default_indexes_for_columns(input_columns: list, table_type: str) -> dict:
-    """Returns applicable indexes for table with input_columns
-
-    :param input_columns:
-    :return:
-    """
-    default_indexes = [
-        (FIELD.ID,),
-        (FIELD.GOBID,),
-        (FIELD.DATE_DELETED,),
-        (FIELD.EXPIRATION_DATE,),
-        (FIELD.APPLICATION,),
-        (FIELD.SOURCE_ID,),  # for application of events
-        (FIELD.LAST_EVENT,)
-    ]
-
-    entity_table_indexes = [
-        (FIELD.ID, FIELD.SEQNR),
-        (FIELD.TID,),
-    ]
-
-    relation_table_indexes = [
-        (FIELD.SOURCE_VALUE,),
-        (FIELD.GOBID, FIELD.EXPIRATION_DATE),
-        (FIELD.SOURCE,),
-        (f"src{FIELD.ID}", f"src_{FIELD.SEQNR}", f"src{FIELD.SOURCE}", FIELD.SOURCE_VALUE, FIELD.APPLICATION),
-        (f"src{FIELD.ID}", f"src_{FIELD.SEQNR}"),
-        (f"dst{FIELD.ID}", f"dst_{FIELD.SEQNR}"),
-        (FIELD.LAST_SRC_EVENT,),
-        (FIELD.LAST_DST_EVENT,),
-    ]
-
-    create_indexes = default_indexes
-
-    if table_type == TABLE_TYPE_ENTITY:
-        create_indexes += entity_table_indexes
-    elif table_type == TABLE_TYPE_RELATION:
-        create_indexes += relation_table_indexes
-
-    result = {}
-    for columns in default_indexes:
-        # Check if all columns defined in index are present
-        if all([column in input_columns for column in columns]):
-            idx_name = "_".join([_remove_leading_underscore(column) for column in columns])
-            result[idx_name] = columns
-    return result
-
-
-def _get_special_column_type(column_type: str):
-    """Returns special column type such as 'geo' or 'json', or else None
-
-    :param column_type:
-    :return:
-    """
-    if is_gob_geo_type(column_type):
-        return "geo"
-    elif is_gob_json_type(column_type):
-        return "json"
-    else:
-        return None
-
-
-def _hashed_index_name(prefix, index_name):
-    return f"{prefix}_{_hash(index_name)}"
-
-
-def _hash(string):
-    return hashlib.md5(string.encode()).hexdigest()
-
-
-def _relation_indexes_for_collection(catalog_name, collection_name, collection, idx_prefix):
-    model = GOBModel()
-    sources = GOBSources()
-
-    indexes = {}
-    table_name = model.get_table_name(catalog_name, collection_name)
-
-    reference_columns = {column: desc['ref'] for column, desc in collection['all_fields'].items() if
-                         desc['type'] in ['GOB.Reference', 'GOB.ManyReference']}
-
-    # Search source and destination attributes for relation and define index
-    for col, ref in reference_columns.items():
-        dst_index_table = model.get_table_name_from_ref(ref)
-        dst_collection = model.get_collection_from_ref(ref)
-        dst_catalog_name, dst_collection_name = model.get_catalog_collection_names_from_ref(ref)
-        dst_catalog = model.get_catalog(dst_catalog_name)
-        relations = sources.get_field_relations(catalog_name, collection_name, col)
-
-        for relation in relations:
-            dst_idx_prefix = f"{dst_catalog['abbreviation']}_{dst_collection['abbreviation']}".lower()
-            src_index_col = f"{relation['source_attribute'] if 'source_attribute' in relation else col}"
-
-            # Source column
-            name = _hashed_index_name(idx_prefix, _remove_leading_underscore(src_index_col))
-            indexes[name] = {
-                "table_name": table_name,
-                "columns": [src_index_col],
-            }
-
-            indexes[name]["type"] = _get_special_column_type(collection['all_fields'][src_index_col]['type'])
-
-            # Destination column
-            name = _hashed_index_name(
-                dst_idx_prefix, _remove_leading_underscore(relation['destination_attribute'])
-            )
-
-            indexes[name] = {
-                "table_name": dst_index_table,
-                "columns": [relation['destination_attribute']],
-                "type": _get_special_column_type(
-                    dst_collection['all_fields'][relation['destination_attribute']]['type']
-                ),
-            }
-
-    return indexes
-
-
-def _derive_indexes() -> dict:
-    model = GOBModel()
-    indexes = {}
-
-    for catalog_name, catalog in model.get_catalogs().items():
-        for collection_name, collection in model.get_collections(catalog_name).items():
-            entity = collection['all_fields']
-            table_name = model.get_table_name(catalog_name, collection_name)
-            is_relation_table = table_name.startswith('rel_')
-
-            if is_relation_table:
-                split_table_name = table_name.split('_')
-                prefix = '_'.join(split_table_name[:5]) + '_' + _hash('_'.join(split_table_name[5:]))[:8]
-            else:
-                prefix = f"{catalog['abbreviation']}_{collection['abbreviation']}".lower()
-
-            # Generate indexes on default columns
-            for idx_name, columns in _default_indexes_for_columns(
-                    list(entity.keys()),
-                    TABLE_TYPE_RELATION if is_relation_table else TABLE_TYPE_ENTITY
-            ).items():
-                indexes[_hashed_index_name(prefix, idx_name)] = {
-                    "columns": columns,
-                    "table_name": table_name,
-                }
-
-            # Add source, last event index
-            columns = [FIELD.SOURCE, FIELD.LAST_EVENT + ' DESC']
-            idx_name = "_".join([_remove_leading_underscore(column) for column in columns])
-            indexes[_hashed_index_name(prefix, idx_name)] = {
-                "columns": columns,
-                "table_name": table_name,
-            }
-
-            # Generate indexes on referenced columns (GOB.Reference and GOB.ManyReference)
-            indexes.update(**_relation_indexes_for_collection(catalog_name, collection_name, collection, prefix))
-
-            # Create special COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone') index
-            indexes[_hashed_index_name(prefix, f"{FIELD.EXPIRATION_DATE}_coalesce")] = {
-                "columns": [f"COALESCE({FIELD.EXPIRATION_DATE}, '9999-12-31'::timestamp without time zone)"],
-                "table_name": table_name,
-            }
-
-    return indexes
-
-
-models = _derive_models()
-indexes = _derive_indexes()

--- a/gobcore/model/sa/gob.py
+++ b/gobcore/model/sa/gob.py
@@ -150,7 +150,13 @@ def get_sqlalchemy_models(model):
     }
 
     # Start with events
-    columns_to_model(model, None, "events", columns_to_fields(EVENTS, EVENTS_DESCRIPTION), constraint_columns=["eventid"])
+    columns_to_model(
+        model,
+        None,
+        "events",
+        columns_to_fields(EVENTS, EVENTS_DESCRIPTION),
+        constraint_columns=["eventid"]
+    )
 
     for catalog_name, catalog in model.get_catalogs().items():
         for collection_name, collection in model.get_collections(catalog_name).items():

--- a/gobcore/model/sa/indexes.py
+++ b/gobcore/model/sa/indexes.py
@@ -1,0 +1,176 @@
+import hashlib
+import re
+from gobcore.model.metadata import FIELD
+from gobcore.sources import GOBSources
+from gobcore.typesystem import is_gob_geo_type, is_gob_json_type
+
+TABLE_TYPE_RELATION = 'relation_table'
+TABLE_TYPE_ENTITY = 'entity_table'
+
+Base = None
+
+
+def _get_special_column_type(column_type: str):
+    """Returns special column type such as 'geo' or 'json', or else None
+
+    :param column_type:
+    :return:
+    """
+    if is_gob_geo_type(column_type):
+        return "geo"
+    elif is_gob_json_type(column_type):
+        return "json"
+    else:
+        return None
+
+
+def _remove_leading_underscore(s: str):
+    return re.sub(r'^_', '', s)
+
+
+def _default_indexes_for_columns(input_columns: list, table_type: str) -> dict:
+    """Returns applicable indexes for table with input_columns
+
+    :param input_columns:
+    :return:
+    """
+    default_indexes = [
+        (FIELD.ID,),
+        (FIELD.GOBID,),
+        (FIELD.DATE_DELETED,),
+        (FIELD.EXPIRATION_DATE,),
+        (FIELD.APPLICATION,),
+        (FIELD.SOURCE_ID,),  # for application of events
+        (FIELD.LAST_EVENT,)
+    ]
+
+    entity_table_indexes = [
+        (FIELD.ID, FIELD.SEQNR),
+        (FIELD.TID,),
+    ]
+
+    relation_table_indexes = [
+        (FIELD.SOURCE_VALUE,),
+        (FIELD.GOBID, FIELD.EXPIRATION_DATE),
+        (FIELD.SOURCE,),
+        (f"src{FIELD.ID}", f"src_{FIELD.SEQNR}", f"src{FIELD.SOURCE}", FIELD.SOURCE_VALUE, FIELD.APPLICATION),
+        (f"src{FIELD.ID}", f"src_{FIELD.SEQNR}"),
+        (f"dst{FIELD.ID}", f"dst_{FIELD.SEQNR}"),
+        (FIELD.LAST_SRC_EVENT,),
+        (FIELD.LAST_DST_EVENT,),
+    ]
+
+    create_indexes = default_indexes
+
+    if table_type == TABLE_TYPE_ENTITY:
+        create_indexes += entity_table_indexes
+    elif table_type == TABLE_TYPE_RELATION:
+        create_indexes += relation_table_indexes
+
+    result = {}
+    for columns in default_indexes:
+        # Check if all columns defined in index are present
+        if all([column in input_columns for column in columns]):
+            idx_name = "_".join([_remove_leading_underscore(column) for column in columns])
+            result[idx_name] = columns
+    return result
+
+
+def _hashed_index_name(prefix, index_name):
+    return f"{prefix}_{_hash(index_name)}"
+
+
+def _hash(string):
+    return hashlib.md5(string.encode()).hexdigest()
+
+
+def _relation_indexes_for_collection(model, catalog_name, collection_name, collection, idx_prefix):
+    sources = GOBSources(model)
+
+    indexes = {}
+    table_name = model.get_table_name(catalog_name, collection_name)
+
+    reference_columns = {column: desc['ref'] for column, desc in collection['all_fields'].items() if
+                         desc['type'] in ['GOB.Reference', 'GOB.ManyReference']}
+
+    # Search source and destination attributes for relation and define index
+    for col, ref in reference_columns.items():
+        dst_index_table = model.get_table_name_from_ref(ref)
+        dst_collection = model.get_collection_from_ref(ref)
+        dst_catalog_name, dst_collection_name = model.get_catalog_collection_names_from_ref(ref)
+        dst_catalog = model.get_catalog(dst_catalog_name)
+        relations = sources.get_field_relations(catalog_name, collection_name, col)
+
+        for relation in relations:
+            dst_idx_prefix = f"{dst_catalog['abbreviation']}_{dst_collection['abbreviation']}".lower()
+            src_index_col = f"{relation['source_attribute'] if 'source_attribute' in relation else col}"
+
+            # Source column
+            name = _hashed_index_name(idx_prefix, _remove_leading_underscore(src_index_col))
+            indexes[name] = {
+                "table_name": table_name,
+                "columns": [src_index_col],
+            }
+
+            indexes[name]["type"] = _get_special_column_type(collection['all_fields'][src_index_col]['type'])
+
+            # Destination column
+            name = _hashed_index_name(
+                dst_idx_prefix, _remove_leading_underscore(relation['destination_attribute'])
+            )
+
+            indexes[name] = {
+                "table_name": dst_index_table,
+                "columns": [relation['destination_attribute']],
+                "type": _get_special_column_type(
+                    dst_collection['all_fields'][relation['destination_attribute']]['type']
+                ),
+            }
+
+    return indexes
+
+
+def get_indexes(model) -> dict:
+    indexes = {}
+
+    for catalog_name, catalog in model.get_catalogs().items():
+        for collection_name, collection in model.get_collections(catalog_name).items():
+            entity = collection['all_fields']
+            table_name = model.get_table_name(catalog_name, collection_name)
+            is_relation_table = table_name.startswith('rel_')
+
+            if is_relation_table:
+                split_table_name = table_name.split('_')
+                prefix = '_'.join(split_table_name[:5]) + '_' + _hash('_'.join(split_table_name[5:]))[:8]
+            else:
+                prefix = f"{catalog['abbreviation']}_{collection['abbreviation']}".lower()
+
+            # Generate indexes on default columns
+            for idx_name, columns in _default_indexes_for_columns(
+                    list(entity.keys()),
+                    TABLE_TYPE_RELATION if is_relation_table else TABLE_TYPE_ENTITY
+            ).items():
+                indexes[_hashed_index_name(prefix, idx_name)] = {
+                    "columns": columns,
+                    "table_name": table_name,
+                }
+
+            # Add source, last event index
+            columns = [FIELD.SOURCE, FIELD.LAST_EVENT + ' DESC']
+            idx_name = "_".join([_remove_leading_underscore(column) for column in columns])
+            indexes[_hashed_index_name(prefix, idx_name)] = {
+                "columns": columns,
+                "table_name": table_name,
+            }
+
+            # Generate indexes on referenced columns (GOB.Reference and GOB.ManyReference)
+            indexes.update(
+                **_relation_indexes_for_collection(model, catalog_name, collection_name, collection, prefix))
+
+            # Create special COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone') index
+            indexes[_hashed_index_name(prefix, f"{FIELD.EXPIRATION_DATE}_coalesce")] = {
+                "columns": [f"COALESCE({FIELD.EXPIRATION_DATE}, '9999-12-31'::timestamp without time zone)"],
+                "table_name": table_name,
+            }
+
+    return indexes

--- a/gobcore/sources/__init__.py
+++ b/gobcore/sources/__init__.py
@@ -8,13 +8,13 @@ from gobcore.model import GOBModel
 
 class GOBSources():
 
-    def __init__(self):
+    def __init__(self, model: GOBModel):
         path = os.path.join(os.path.dirname(__file__), 'gobsources.json')
         with open(path) as file:
             data = json.load(file)
 
         self._data = data
-        self._model = GOBModel()
+        self._model = model
 
         self._relations = defaultdict(lambda: defaultdict(list))
 

--- a/tests/gobcore/model/sa/test_gob.py
+++ b/tests/gobcore/model/sa/test_gob.py
@@ -10,11 +10,28 @@ class TestGob(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_model(self):
+    def test_get_sqlalchemy_models(self):
         models = get_sqlalchemy_models(GOBModel())
         for (name, cls) in models.items():
             m = cls()
             self.assertEqual(str(m), name)
+
+    @patch("gobcore.model.sa.gob.columns_to_model")
+    def test_get_sqlalchemy_models_already_initialised(self, mock_columns_to_model):
+        gobmodel = GOBModel()
+        GOBModel.sqlalchemy_models = None
+
+        models = get_sqlalchemy_models(gobmodel)
+        mock_columns_to_model.assert_called()
+
+        self.assertIsNotNone(GOBModel.sqlalchemy_models)
+        self.assertEqual(GOBModel.sqlalchemy_models, models)
+
+        # Should used cached value the second time
+        mock_columns_to_model.reset_mock()
+        models = get_sqlalchemy_models(gobmodel)
+        mock_columns_to_model.assert_not_called()
+        self.assertEqual(GOBModel.sqlalchemy_models, models)
 
     class MockModel:
         collections = {

--- a/tests/gobcore/model/sa/test_indexes.py
+++ b/tests/gobcore/model/sa/test_indexes.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import patch
+
+from gobcore.model.sa.indexes import _get_special_column_type
+
+
+class TestIndexes(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @patch("gobcore.model.sa.indexes.is_gob_geo_type", lambda x: x is not None and x.startswith('geo'))
+    @patch("gobcore.model.sa.indexes.is_gob_json_type", lambda x: x is not None and x.startswith('json'))
+    def test_get_special_column_type(self):
+        self.assertEqual("geo", _get_special_column_type("geocolumn"))
+        self.assertEqual("json", _get_special_column_type("jsoncolumn"))
+        self.assertIsNone(_get_special_column_type(None))

--- a/tests/gobcore/model/sa/test_indexes.py
+++ b/tests/gobcore/model/sa/test_indexes.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import patch
 
-from gobcore.model.sa.indexes import _get_special_column_type
+from gobcore.model import FIELD
+from gobcore.model.sa.indexes import _get_special_column_type, get_indexes
 
 
 class TestIndexes(unittest.TestCase):
@@ -15,3 +16,300 @@ class TestIndexes(unittest.TestCase):
         self.assertEqual("geo", _get_special_column_type("geocolumn"))
         self.assertEqual("json", _get_special_column_type("jsoncolumn"))
         self.assertIsNone(_get_special_column_type(None))
+
+    class MockModelForGetIndexes:
+        model = {
+            'catalog_a': {
+                'abbreviation': 'ca',
+                'collections': {
+                    'collection_a1': {
+                        'abbreviation': 'coa1',
+                        'all_fields': {
+                            FIELD.ID: {'type': 'GOB.String'},
+                            FIELD.APPLICATION: {'type': 'GOB.String'},
+                            'a': {'type': 'GOB.String'}
+                        }
+                    },
+                    'collection_a2': {
+                        'abbreviation': 'coa2',
+                        'all_fields': {
+                            FIELD.GOBID: {'type': 'GOB.String'},
+                            FIELD.SEQNR: {'type': 'GOB.Integer'},
+                            FIELD.ID: {'type': 'GOB.String'},
+                            'reference': {
+                                'type': 'GOB.Reference',
+                                'ref': 'catalog_a:collection_a1'
+                            },
+                            'manyreference': {
+                                'type': 'GOB.ManyReference',
+                                'ref': 'catalog_a:collection_a1'
+                            },
+                            'geocol': {
+                                'type': 'GOB.Geometry'
+                            },
+                            'json': {
+                                'type': 'GOB.JSON'
+                            },
+                            'str': {
+                                'type': 'GOB.String'
+                            }
+                        }
+                    }
+                }
+            },
+            'catalog_b': {
+                'abbreviation': 'cb',
+                'collections': {
+                    'collection_b3': {
+                        'abbreviation': 'cob3',
+                        'all_fields': {
+                            FIELD.EXPIRATION_DATE: {'type': 'GOB.DateTime'}
+                        }
+                    }
+                }
+            },
+            'rel': {
+                'abbreviation': 'rel',
+                'collections': {
+                    'relation_a': {
+                        'abbreviation': 'ra',
+                        'all_fields': {
+                            FIELD.SOURCE_VALUE: {'type': 'GOB.String'},
+                            FIELD.GOBID: {'type': 'GOB.String'},
+                            FIELD.EXPIRATION_DATE: {'type': 'GOB.DateTime'}
+                        }
+                    },
+                    'relation_b': {
+                        'abbreviation': 'rb',
+                        'all_fields': {
+                            f'src{FIELD.ID}': {'type': 'GOB.String'},
+                            f'src{FIELD.SEQNR}': {'type': 'GOB.Integer'},
+                            f'dst{FIELD.ID}': {'type': 'GOB.String'},
+                            f'dst{FIELD.SEQNR}': {'type': 'GOB.Integer'},
+                            f'src{FIELD.SOURCE}': {'type': 'GOB.String'},
+                            FIELD.SOURCE_VALUE: {'type': 'GOB.String'},
+                            FIELD.APPLICATION: {'type': 'GOB.String'},
+                            FIELD.LAST_SRC_EVENT: {'type': 'GOB.Integer'}
+                        }
+                    }
+                }
+            }
+        }
+
+        def get_catalogs(self):
+            return self.model
+
+        def get_catalog(self, catalog_name):
+            return self.model[catalog_name]
+
+        def get_collections(self, catalog_name):
+            return self.model[catalog_name]['collections']
+
+        def get_table_name(self, catalog_name, collection_name):
+            return f"{catalog_name}_{collection_name}"
+
+        def get_table_name_from_ref(self, ref: str):
+            return ref.replace(':', '_')
+
+        def get_collection_from_ref(self, ref: str):
+            cat, coll = self.get_catalog_collection_names_from_ref(ref)
+            return self.get_collections(cat)[coll]
+
+        def get_catalog_collection_names_from_ref(self, ref: str):
+            spl = ref.split(':')
+            return spl[0], spl[1]
+
+    class MockSourcesForGetIndexes():
+        sources = {
+            'catalog_a': {
+                'collection_a2': {
+                    'reference': [{
+                        'destination_attribute': 'a',
+                    }],
+                    'manyreference': [{
+                        'source_attribute': 'str',
+                        'destination_attribute': 'a',
+                    }]
+                }
+            }
+        }
+
+        def __init__(self, model):
+            pass
+
+        def get_field_relations(self, catalog_name, collection_name, col):
+            return self.sources[catalog_name][collection_name][col]
+
+    @patch("gobcore.model.sa.indexes.GOBSources", MockSourcesForGetIndexes)
+    def test_get_indexes(self):
+        result = get_indexes(self.MockModelForGetIndexes())
+
+        expected = {
+            'ca_coa1_b80bb7740288fda1f201890375a60c8f': {
+                'columns': (
+                    '_id',
+                ),
+                'table_name': 'catalog_a_collection_a1'
+            },
+            'ca_coa1_3676d55f84497cbeadfc614c1b1b62fc': {
+                'columns': (
+                    '_application',
+                ),
+                'table_name': 'catalog_a_collection_a1'
+            },
+            'ca_coa1_37abd7da5cbd49b20a1090ba960d82e7': {
+                'columns': [
+                    '_source',
+                    '_last_event DESC'
+                ],
+                'table_name': 'catalog_a_collection_a1'
+            },
+            'ca_coa1_ed3f22b3eec2fb035647f924a5b2136e': {
+                'columns': [
+                    "COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone)"
+                ],
+                'table_name': 'catalog_a_collection_a1'
+            },
+            'ca_coa2_b80bb7740288fda1f201890375a60c8f': {
+                'columns': (
+                    '_id',
+                ),
+                'table_name': 'catalog_a_collection_a2'
+            },
+            'ca_coa2_d05569f886377400312d8c2edd4c6f4c': {
+                'columns': (
+                    '_gobid',
+                ),
+                'table_name': 'catalog_a_collection_a2'
+            },
+            'ca_coa2_2a4dbedb477015cfe2b9f2c990906f44': {
+                'columns': (
+                    '_id',
+                    'volgnummer'
+                ),
+                'table_name': 'catalog_a_collection_a2'
+            },
+            'ca_coa2_37abd7da5cbd49b20a1090ba960d82e7': {
+                'columns': [
+                    '_source',
+                    '_last_event DESC'
+                ],
+                'table_name': 'catalog_a_collection_a2'
+            },
+            'ca_coa2_b8af13ea9c8fe890c9979a1fa8dbde22': {
+                'table_name': 'catalog_a_collection_a2',
+                'columns': [
+                    'reference'
+                ],
+                'type': 'json'
+            },
+            'ca_coa1_0cc175b9c0f1b6a831c399e269772661': {
+                'table_name': 'catalog_a_collection_a1',
+                'columns': [
+                    'a'
+                ],
+                'type': None
+            },
+            'ca_coa2_341be97d9aff90c9978347f66f945b77': {
+                'table_name': 'catalog_a_collection_a2',
+                'columns': [
+                    'str'
+                ],
+                'type': None
+            },
+            'ca_coa2_ed3f22b3eec2fb035647f924a5b2136e': {
+                'columns': [
+                    "COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone)"
+                ],
+                'table_name': 'catalog_a_collection_a2'
+            },
+            'cb_cob3_1a9d849ff5a68997176b6144236806ae': {
+                'columns': (
+                    '_expiration_date',
+                ),
+                'table_name': 'catalog_b_collection_b3'
+            },
+            'cb_cob3_37abd7da5cbd49b20a1090ba960d82e7': {
+                'columns': [
+                    '_source',
+                    '_last_event DESC'
+                ],
+                'table_name': 'catalog_b_collection_b3'
+            },
+            'cb_cob3_ed3f22b3eec2fb035647f924a5b2136e': {
+                'columns': [
+                    "COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone)"
+                ],
+                'table_name': 'catalog_b_collection_b3'
+            },
+            'rel_relation_a_d41d8cd9_d05569f886377400312d8c2edd4c6f4c': {
+                'columns': (
+                    '_gobid',
+                ),
+                'table_name': 'rel_relation_a'
+            },
+            'rel_relation_a_d41d8cd9_1a9d849ff5a68997176b6144236806ae': {
+                'columns': (
+                    '_expiration_date',
+                ),
+                'table_name': 'rel_relation_a'
+            },
+            'rel_relation_a_d41d8cd9_ab35fb2f74ba637ec5dff03e521947fc': {
+                'columns': (
+                    'bronwaarde',
+                ),
+                'table_name': 'rel_relation_a'
+            },
+            'rel_relation_a_d41d8cd9_4acfc3d0636d198ba3ed562be2273f9e': {
+                'columns': (
+                    '_gobid',
+                    '_expiration_date'
+                ),
+                'table_name': 'rel_relation_a'
+            },
+            'rel_relation_a_d41d8cd9_37abd7da5cbd49b20a1090ba960d82e7': {
+                'columns': [
+                    '_source',
+                    '_last_event DESC'
+                ],
+                'table_name': 'rel_relation_a'
+            },
+            'rel_relation_a_d41d8cd9_ed3f22b3eec2fb035647f924a5b2136e': {
+                'columns': [
+                    "COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone)"
+                ],
+                'table_name': 'rel_relation_a'
+            },
+            'rel_relation_b_d41d8cd9_3676d55f84497cbeadfc614c1b1b62fc': {
+                'columns': (
+                    '_application',
+                ),
+                'table_name': 'rel_relation_b'
+            },
+            'rel_relation_b_d41d8cd9_ab35fb2f74ba637ec5dff03e521947fc': {
+                'columns': (
+                    'bronwaarde',
+                ),
+                'table_name': 'rel_relation_b'
+            },
+            'rel_relation_b_d41d8cd9_dc79a884dc55f09863437f9198baf021': {
+                'columns': (
+                    '_last_src_event',
+                ),
+                'table_name': 'rel_relation_b'
+            },
+            'rel_relation_b_d41d8cd9_37abd7da5cbd49b20a1090ba960d82e7': {
+                'columns': [
+                    '_source',
+                    '_last_event DESC'
+                ],
+                'table_name': 'rel_relation_b'
+            },
+            'rel_relation_b_d41d8cd9_ed3f22b3eec2fb035647f924a5b2136e': {
+                'columns': [
+                    "COALESCE(_expiration_date, '9999-12-31'::timestamp without time zone)"
+                ],
+                'table_name': 'rel_relation_b'
+            }
+        }
+        self.assertEquals(result, expected)

--- a/tests/gobcore/model/test_model.py
+++ b/tests/gobcore/model/test_model.py
@@ -13,6 +13,10 @@ class TestModel(unittest.TestCase):
     def setUp(self):
         self.model = GOBModel()
 
+    def test_fail_on_different_legacy_value(self):
+        with self.assertRaisesRegex(Exception, "Tried to initialise model with different legacy setting"):
+            GOBModel(legacy=True)
+
     def test_get_catalog_names(self):
         self.assertIn('meetbouten', self.model.get_catalog_names())
 

--- a/tests/gobcore/sources/test_sources.py
+++ b/tests/gobcore/sources/test_sources.py
@@ -15,7 +15,19 @@ class TestSources(unittest.TestCase):
         # Assert we get a list of relations for a collection
         self.assertIsInstance(self.sources.get_relations('nap', 'peilmerken'), list)
 
-    def test_get_field_relations_keyerror(self):
+    def test_get_field_relations(self):
+        self.sources.get_relations = MagicMock(return_value=[{
+            'field_name': 'fieldname',
+            'bla': 'bla'
+        }, {
+            'field_name': 'someother',
+            'bla': 'die'
+        }])
+        self.assertEqual([{
+            'field_name': 'fieldname',
+            'bla': 'bla'
+        }], self.sources.get_field_relations('catalog', 'collection', 'fieldname'))
+
         self.sources.get_relations = MagicMock(side_effect=KeyError)
 
         self.assertEqual([], self.sources.get_field_relations('catalog', 'collection', 'fieldname'))

--- a/tests/gobcore/sources/test_sources.py
+++ b/tests/gobcore/sources/test_sources.py
@@ -1,13 +1,15 @@
 import unittest
 from unittest.mock import MagicMock
 
+from gobcore.model import GOBModel
 from gobcore.sources import GOBSources
 
 
 class TestSources(unittest.TestCase):
 
     def setUp(self):
-        self.sources = GOBSources()
+        model = GOBModel()
+        self.sources = GOBSources(model)
 
     def test_get_relations(self):
         # Assert we get a list of relations for a collection


### PR DESCRIPTION
In preparation for legacy mode.

BREAKING CHANGES:
- Replace use of gobcore.model.sa.indexes with a call to gobcore.model.indexes.get_indexes
- Replace use of gobcore.model.sa.models with a call to gobcore.model.sa.get_sqlalchemy_models
- GOBSources needs to be initialised with an existing GOBModel from now on

GOBModel cannot be initialised in a service with both legacy True and legacy False. However, True should only be used from GOB-API.

Added some new tests for code that was previously executed during the test suite, but never really tested.

Besides the check for the legacy parameter (unused in this PR, usage will follow in a new PR), there are NO functional changes in this PR.