### PR TITLE
Change nap_peilmerken enhanced view to run on legacy schema

### DIFF
--- a/gobcore/views/nap/peilmerken/enhanced.sql
+++ b/gobcore/views/nap/peilmerken/enhanced.sql
@@ -1,12 +1,12 @@
     SELECT identificatie
     ,      hoogte_tov_nap
     ,      jaar
-    ,      json_build_object('code', merk_code, 'omschrijving', merk_omschrijving) as merk
+    ,      merk
     ,      omschrijving
     ,      windrichting
     ,      x_coordinaat_muurvlak
     ,      y_coordinaat_muurvlak
     ,      rws_nummer
     ,      geometrie
-    FROM  nap_peilmerken
+    FROM  legacy.nap_peilmerken
     WHERE publiceerbaar = TRUE


### PR DESCRIPTION
Instead of changing the query to read from public Amsterdam Schema model, read from legacy schema and initialise from API.