### PR TITLE
Use logger and heartbeat context manager, get logger name from service

### DIFF
--- a/gobcore/logging/logger.py
+++ b/gobcore/logging/logger.py
@@ -119,7 +119,7 @@ class Logger:
         self.messages = defaultdict(list)
 
     def __repr__(self):
-        return f"{super().__repr__()}<{self.name}>"
+        return f"{super().__repr__()}<{getattr(self, 'name', 'NOT SET')}>"
 
     def clear_issues(self):
         self._issues.clear()

--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -17,7 +17,7 @@ from gobcore.utils import get_logger_name
 
 CHECK_CONNECTION = 5                # Check connection every n seconds
 RUNS_IN_OWN_THREAD = "own_thread"   # Service that runs in a separate thread
-LOGGER_HANDLERS = [StdoutHandler(), RequestsHandler()]
+LOG_HANDLERS = [StdoutHandler(), RequestsHandler()]
 
 # Assure that heartbeats are sent at every HEARTBEAT_INTERVAL
 assert(HEARTBEAT_INTERVAL % CHECK_CONNECTION == 0)

--- a/gobcore/message_broker/messagedriven_service.py
+++ b/gobcore/message_broker/messagedriven_service.py
@@ -1,12 +1,10 @@
 import sys
-import time
 import threading
-from typing import Callable, Dict, Any, Optional
+import time
+from typing import Any, Optional
 
 from gobcore.logging.logger import logger, StdoutHandler, RequestsHandler
 from gobcore.message_broker.async_message_broker import AsyncConnection
-from gobcore.message_broker.typing import Service, ServiceDefinition
-from gobcore.status.heartbeat import Heartbeat, HEARTBEAT_INTERVAL, STATUS_OK, STATUS_START, STATUS_FAIL
 from gobcore.message_broker.config import CONNECTION_PARAMS
 from gobcore.message_broker.initialise_queues import initialize_message_broker
 from gobcore.message_broker.notifications import contains_notification, send_notification

--- a/gobcore/standalone.py
+++ b/gobcore/standalone.py
@@ -11,6 +11,7 @@ from gobcore.message_broker.utils import to_json, from_json
 from gobcore.utils import get_logger_name
 
 Message = Dict[str, Any]
+LOG_HANDLERS = [StdoutHandler()]
 
 
 def parent_argument_parser() -> Tuple[argparse.ArgumentParser, argparse._SubParsersAction]:
@@ -67,7 +68,7 @@ def run_as_standalone(
 
     service = service_definition[args.handler]
 
-    with logger.configure_context(message_in, get_logger_name(service), handlers=[StdoutHandler()]):
+    with logger.configure_context(message_in, get_logger_name(service), LOG_HANDLERS):
         message_out = service["handler"](message_in)
 
     message_out_offloaded = offload_message(

--- a/gobcore/standalone.py
+++ b/gobcore/standalone.py
@@ -1,12 +1,11 @@
 import argparse
 import json
-from gobcore.logging.logger import logger, StdoutHandler
 from pathlib import Path
 from typing import Dict, Any, Tuple
 
-from gobcore.message_broker.typing import ServiceDefinition
-from gobcore.utils import get_logger_name
+from gobcore.logging.logger import logger, StdoutHandler
 from gobcore.message_broker.offline_contents import offload_message, load_message
+from gobcore.message_broker.typing import ServiceDefinition
 from gobcore.message_broker.utils import to_json, from_json
 from gobcore.utils import get_logger_name
 

--- a/gobcore/status/heartbeat.py
+++ b/gobcore/status/heartbeat.py
@@ -15,7 +15,7 @@ import datetime
 import threading
 import socket
 import os
-from typing import Union, Optional
+from typing import Union
 
 from gobcore.message_broker import AsyncConnection
 from gobcore.message_broker.config import STATUS_EXCHANGE, HEARTBEAT_KEY, PROGRESS_KEY
@@ -65,10 +65,9 @@ class Heartbeat:
         :param connection: The message broker connection
         :param service: The definition of the service that delivered the message
         :param msg: The message being processed
-        :param status: The status to report (STATUS_START, STATUS_OK or STATUS_FAIL)
         :return: None
         """
-        def _publish_progress(status: Status, info_msg: str = None):
+        def _publish_progress(status: JobStatus, info_msg: str = None):
             if service.get("report") and msg.get("header"):
                 jobid = msg["header"].get("jobid")
                 stepid = msg["header"].get("stepid")

--- a/gobcore/status/heartbeat.py
+++ b/gobcore/status/heartbeat.py
@@ -10,6 +10,7 @@ when the service has reported itself dead via the atexit method
 
 """
 import atexit
+import contextlib
 import datetime
 import threading
 import socket
@@ -54,14 +55,8 @@ class Heartbeat:
     progress_key = PROGRESS_KEY
 
     @classmethod
-    def progress(
-            cls,
-            connection: AsyncConnection,
-            service: Service,
-            msg: dict,
-            status: JobStatus,
-            info_msg: Optional[str] = None
-    ):
+    @contextlib.contextmanager
+    def progress(cls, connection: AsyncConnection, service: Service, msg: dict):
         """
         Send a progress heartbeat
 
@@ -73,22 +68,35 @@ class Heartbeat:
         :param status: The status to report (STATUS_START, STATUS_OK or STATUS_FAIL)
         :return: None
         """
-        if service.get("report") and msg.get("header"):
-            jobid = msg["header"].get("jobid")
-            stepid = msg["header"].get("stepid")
-            if jobid and stepid:
-                # Log progress on stdout
-                print(cls._progress_log_msg(service.get('queue'), status, msg['header']))
-                # Publish progress
-                connection.publish(cls.exchange, cls.progress_key, {
-                    # Include header so that any logs get reported on the correct job
-                    "header": msg["header"],
-                    # Include the specific status fields
-                    "jobid": jobid,
-                    "stepid": stepid,
-                    "status": status,
-                    "info_msg": info_msg
-                })
+        def _publish_progress(status: Status, info_msg: str = None):
+            if service.get("report") and msg.get("header"):
+                jobid = msg["header"].get("jobid")
+                stepid = msg["header"].get("stepid")
+
+                if jobid and stepid:
+                    # Log progress on stdout
+                    print(cls._progress_log_msg(service.get('queue'), status, msg['header']))
+
+                    publish_msg = {
+                        # Include header so that any logs get reported on the correct job
+                        "header": msg["header"],
+                        # Include the specific status fields
+                        "jobid": jobid,
+                        "stepid": stepid,
+                        "status": status,
+                        "info_msg": info_msg
+                    }
+                    connection.publish(cls.exchange, cls.progress_key, publish_msg)
+
+        try:
+            _publish_progress(STATUS_START)
+            yield
+            _publish_progress(STATUS_OK)
+        except Exception as err:
+            _publish_progress(STATUS_FAIL, str(err))
+            raise err
+        finally:
+            pass
 
     @classmethod
     def _progress_log_msg(cls, queue: str, status: JobStatus, header: dict) -> str:

--- a/gobcore/utils.py
+++ b/gobcore/utils.py
@@ -134,12 +134,17 @@ def get_filename(name: str, offload_folder: str) -> str:
 
 
 def get_logger_name(service: Service) -> str:
-    """Creates a name for a logger from a given handler.
-
-    If handler has no __name__ attribute (like mocks or lambda's), it uses the
-    string representation of the function.
+    """
+    Creates a name for a logger from the servicedefinition.
+    This is defined by the `logger` key, with a fallback to the queue name.
+    The returned value must be a string, nameless loggers are not allowed.
 
     :param service: A service, as defined in SERVICEDEFINITION.
     :return: a name to configure a logger with.
     """
-    return service.get("logger", service["queue"].split(".")[-2]).upper()
+    name = service.get("logger", service["queue"].split(".")[-2])
+
+    if not isinstance(name, str):
+        raise TypeError(f"Name must be str type, got: {type(name)}")
+
+    return name.upper()

--- a/gobcore/utils.py
+++ b/gobcore/utils.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 from datetime import datetime
 from itertools import chain
 from pathlib import Path
@@ -8,6 +6,7 @@ from sys import getsizeof
 import uuid
 
 from gobcore.message_broker.config import GOB_SHARED_DIR
+from gobcore.message_broker.typing import Service
 
 
 def gettotalsizeof(o):
@@ -134,16 +133,13 @@ def get_filename(name: str, offload_folder: str) -> str:
     return str(path / name)
 
 
-def get_logger_name(handler: Callable):
+def get_logger_name(service: Service) -> str:
     """Creates a name for a logger from a given handler.
 
     If handler has no __name__ attribute (like mocks or lambda's), it uses the
     string representation of the function.
 
-    :param handler: A callable, as defined in SERVICEDEFINITION.
+    :param service: A service, as defined in SERVICEDEFINITION.
     :return: a name to configure a logger with.
     """
-    if not hasattr(handler, "__name__"):
-        return str(handler)
-
-    return handler.__name__.upper()
+    return service.get("logger", service["queue"].split(".")[-2]).upper()

--- a/tests/gobcore/fixtures.py
+++ b/tests/gobcore/fixtures.py
@@ -4,6 +4,7 @@ import string
 from gobcore.events import GOB, GOB_EVENTS
 from gobcore.events import import_events
 from gobcore.events.import_message import MessageMetaData
+from gobcore.message_broker.config import _build_queuename
 
 
 class Entity(object):
@@ -21,8 +22,19 @@ def random_string(length=12, source=None):
 
 def get_service_fixture(handler):
     return {
+        'queue': _build_queuename(random_string(), random_string(), random_string()),
+        'handler': handler,
+        'report': {
+            'exchange': random_string(),
+            'key': random_string()
+        }
+    }
+
+
+def get_servicedefinition_fixture(handler):
+    return {
         random_string(): {
-            'queue': random_string(),
+            'queue': _build_queuename(random_string(), random_string(), random_string()),
             'handler': handler,
             'report': {
                 'exchange': random_string(),
@@ -30,6 +42,7 @@ def get_service_fixture(handler):
             }
         }
     }
+
 
 def random_bool():
     return random.choice([True, False])

--- a/tests/gobcore/fixtures.py
+++ b/tests/gobcore/fixtures.py
@@ -31,9 +31,9 @@ def get_service_fixture(handler):
     }
 
 
-def get_servicedefinition_fixture(handler):
+def get_servicedefinition_fixture(handler, workflow: str = None):
     return {
-        random_string(): {
+        workflow or random_string(): {
             'queue': _build_queuename(random_string(), random_string(), random_string()),
             'handler': handler,
             'report': {

--- a/tests/gobcore/logging/test_logger.py
+++ b/tests/gobcore/logging/test_logger.py
@@ -422,9 +422,6 @@ class TestLoggerManager(TestCase):
             logger_manager.name = None
 
         with self.assertRaises(TypeError):
-            logger_manager.name = None
-
-        with self.assertRaises(TypeError):
             logger_manager.name = 1234
 
     def test_configure_context(self):

--- a/tests/gobcore/logging/test_logger.py
+++ b/tests/gobcore/logging/test_logger.py
@@ -24,7 +24,10 @@ class TestLogger(TestCase):
 
     def test_repr(self):
         logger = Logger("new")
-        self.assertIn(logger.name, repr(logger))
+        self.assertTrue(repr(logger).endswith("<new>"))
+
+        logger = Logger()
+        self.assertTrue(repr(logger).endswith("<NOT SET>"))
 
     def test_get_warnings(self):
         logger = Logger()

--- a/tests/gobcore/logging/test_logger.py
+++ b/tests/gobcore/logging/test_logger.py
@@ -418,8 +418,8 @@ class TestLoggerManager(TestCase):
         logger_manager.name = "new name"
         self.assertEqual("new name", logger_manager.name)
 
-        logger_manager.name = None
-        self.assertIsNone(logger_manager.name)
+        with self.assertRaises(TypeError):
+            logger_manager.name = None
 
         with self.assertRaises(TypeError):
             logger_manager.name = None

--- a/tests/gobcore/logging/test_logger.py
+++ b/tests/gobcore/logging/test_logger.py
@@ -418,6 +418,9 @@ class TestLoggerManager(TestCase):
         logger_manager.name = "new name"
         self.assertEqual("new name", logger_manager.name)
 
+        logger_manager.name = None
+        self.assertIsNone(logger_manager.name)
+
         with self.assertRaises(TypeError):
             logger_manager.name = None
 

--- a/tests/gobcore/test_standalone.py
+++ b/tests/gobcore/test_standalone.py
@@ -1,9 +1,14 @@
 import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 import pytest
 from argparse import ArgumentParser
-from mock import Mock
+from unittest.mock import Mock, patch
 
+from gobcore.logging.logger import StdoutHandler
 from gobcore.standalone import run_as_standalone, parent_argument_parser, _build_message
+from tests.gobcore.fixtures import get_servicedefinition_fixture
 
 
 class TestStandalone:
@@ -28,29 +33,31 @@ class TestStandalone:
         )
         return parser
 
-    def test_run_as_standalone(self, arg_parser: ArgumentParser):
+    @pytest.fixture
+    def result_path(self):
+        with TemporaryDirectory() as tmp_dir:
+            yield Path(tmp_dir, "return.json")
+
+    def test_run_as_standalone(self, arg_parser: ArgumentParser, result_path: Path):
         args = arg_parser.parse_args([
             "import", "--catalogue", "test_catalogue", "--mode", "full"
         ])
-        mock_handler = Mock(return_value={})
-        SERVICEDEFINITION = {
-            "import": {
-                "handler": mock_handler
-            }
-        }
-        assert run_as_standalone(args, SERVICEDEFINITION) == 0
-        mock_handler.assert_called_with({
-            "header": {
-                "catalogue": "test_catalogue",
-                "collection": None,
-                "entity": None,
-                "attribute": None,
-                "application": None,
-                "mode": "full"
-            }
-        })
+        args.message_result_path = result_path
 
-    def test_run_as_standalone_no_mode(self):
+        mock_handler = Mock(return_value={})
+        servicedefinition = get_servicedefinition_fixture(mock_handler, "import")
+        servicedefinition["import"]["logger"] = "the logger"
+
+        message_in = {'header': {'catalogue': 'test_catalogue', 'collection': None, 'entity': None, 'attribute': None, 'application': None, 'mode': 'full'}}
+
+        with patch("gobcore.standalone.logger") as mock_logger:
+            assert run_as_standalone(args, servicedefinition) == 0
+
+            mock_logger.configure.assert_called_with(message_in, "THE LOGGER", handlers=[StdoutHandler])
+
+        mock_handler.assert_called_with(message_in)
+
+    def test_run_as_standalone_no_mode(self, result_path: Path):
         # Arg parser without mode
         arg_parser, subparsers = parent_argument_parser()
         import_parser = subparsers.add_parser(
@@ -64,13 +71,11 @@ class TestStandalone:
         args = arg_parser.parse_args([
             "import", "--catalogue", "test_catalogue"
         ])
+        args.message_result_path = result_path
         mock_handler = Mock(return_value={})
-        SERVICEDEFINITION = {
-            "import": {
-                "handler": mock_handler
-            }
-        }
-        assert run_as_standalone(args, SERVICEDEFINITION) == 0
+        servicedefinition = get_servicedefinition_fixture(mock_handler, "import")
+
+        assert run_as_standalone(args, servicedefinition) == 0
         mock_handler.assert_called_with({
             "header": {
                 "catalogue": "test_catalogue",
@@ -82,24 +87,23 @@ class TestStandalone:
             }
         })
 
-    def test_run_as_standalone_error(self, arg_parser: ArgumentParser):
+    def test_run_as_standalone_error(self, arg_parser: ArgumentParser, result_path: Path):
         args = arg_parser.parse_args([
             "import", "--catalogue", "test_catalogue"
         ])
+        args.message_result_path = result_path
+
         summary = {
             "errors": ["An error occurred"],
         }
         mock_handler = Mock(return_value={"summary": summary})
-        SERVICEDEFINITION = {
-            "import": {
-                "handler": mock_handler
-            }
-        }
-        assert run_as_standalone(args, SERVICEDEFINITION) == 1  # error
+        servicedefinition = get_servicedefinition_fixture(mock_handler, "import")
+
+        assert run_as_standalone(args, servicedefinition) == 1  # error
         mock_handler.assert_called()
 
     def test_run_as_standalone_error_handler_not_defined(
-            self, arg_parser: ArgumentParser
+            self, arg_parser: ArgumentParser, result_path: Path
     ):
         """Test if an error is raised when handler is not in service definition.
 
@@ -109,21 +113,19 @@ class TestStandalone:
         args = arg_parser.parse_args([
             "import", "--catalogue", "test_catalogue"
         ])
+        args.message_result_path = result_path
         summary = {
             "errors": ["An error occurred"],
         }
         mock_handler = Mock(return_value={"summary": summary})
-        SERVICEDEFINITION = {
-            "another_handler": {
-                "handler": mock_handler
-            }
-        }
+        servicedefinition = get_servicedefinition_fixture(mock_handler, "another_handler")
+
         with pytest.raises(KeyError):
-            run_as_standalone(args, SERVICEDEFINITION)
+            run_as_standalone(args, servicedefinition)
 
         mock_handler.assert_not_called()
 
-    def test_build_message_pass_message(self):
+    def test_build_message_pass_message(self, result_path: Path):
         """Test if message-data coming in is just passed along."""
         message_data_json = json.dumps(
             {
@@ -134,11 +136,11 @@ class TestStandalone:
                     "enrich": {}, "version": "0.1",
                     "timestamp": "2022-08-25T14:25:37.118522"
                 },
-             "summary": {
-                 "num_records": 1396, "warnings": [], "errors": [],
-                 "log_counts": {"data_warning": 132}
-             },
-             "contents_ref": "/app/shared/message_broker/20220825.142531.48048adc-cf34-42b5-a344-c8edbed9ff16"}
+                "summary": {
+                    "num_records": 1396, "warnings": [], "errors": [],
+                    "log_counts": {"data_warning": 132}
+                },
+                "contents_ref": "/app/shared/message_broker/20220825.142531.48048adc-cf34-42b5-a344-c8edbed9ff16"}
         )
         parser, subparsers = parent_argument_parser()
         subparsers.add_parser(
@@ -149,6 +151,7 @@ class TestStandalone:
             f"--message-data={message_data_json}",
             "compare",
         ])
+        args.message_result_path = result_path
 
         message = _build_message(args)
         assert message["header"]["catalogue"] == "nap"
@@ -161,4 +164,4 @@ class TestStandalone:
         ])
         message = _build_message(args)
         assert message["header"]["catalogue"] == "test_catalogue"
-        assert message["header"]["collection"] == None
+        assert message["header"]["collection"] is None


### PR DESCRIPTION
Depends on: 

- https://github.com/Amsterdam/GOB-Core/pull/670 
- https://github.com/Amsterdam/GOB-Core/pull/672

On every message:
- Wrap the Heartbeat.progress logic in a contextmanager
- Use logger.configure_context to log to this logger in this context only
- Get the logger name from the service. From either a defined "logger" key or use the queue name as fallback.