### PR TITLE
Migrate nabij_nummeraanduiding relations in legacy model to JSON, as it should have been

### DIFF
--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -437,9 +437,13 @@
             "description": "Unieke identificatie van de meetbout"
           },
           "nabij_nummeraanduiding": {
-            "type": "GOB.Reference",
+            "type": "GOB.JSON",
             "description": "Een adres in de nabijheid van de meetbout",
-            "ref": "bag:nummeraanduidingen"
+            "attributes": {
+              "bronwaarde": {
+                "type": "GOB.String"
+              }
+            }
           },
           "locatie": {
             "type": "GOB.String",
@@ -622,9 +626,13 @@
             "description": "Unieke identificatie van de meting"
           },
           "nabij_nummeraanduiding": {
-            "type": "GOB.Reference",
+            "type": "GOB.JSON",
             "description": "Een adres in de nabijheid van het referentiepunt",
-            "ref": "bag:nummeraanduidingen"
+            "attributes": {
+              "bronwaarde": {
+                "type": "GOB.String"
+              }
+            }
           },
           "locatie": {
             "type": "GOB.String",


### PR DESCRIPTION
Used to be a relation, but was never related as the bronwaarde was just an address. Migrated to 'object' in amsterdam schema. Caused backwards compatibility issues. Changing it to a JSON solved the issues, without causing backwards compatibility issues, as we only used the 'bronwaarde' in our exports (because there was never a relation).