### PR TITLE
Allow "type" property (brk2 kadastralesubjecten woonadres).

### DIFF
--- a/gobcore/typesystem/__init__.py
+++ b/gobcore/typesystem/__init__.py
@@ -1,4 +1,4 @@
-"""GOB Data types
+"""GOB Data types.
 
 GOB data consists of entities with attributes, eg Meetbout = { identificatie, locatie, ... }
 The possible types for each attribute are defined in this module.
@@ -77,16 +77,15 @@ _gob_postgres_sql_types_list = [
 
 
 def enhance_type_info(type_info):
-    """
-    Enhance type info with gob types
+    """Enhance type info with gob types.
 
     For every type attribute a corresponding gob_type attribute is set
-    that contains the GOB type class
+    that contains the GOB type class.
 
     :param type_info:
     :return:
     """
-    if type_info.get("type"):
+    if type_info.get("type") and not isinstance(type_info["type"], dict):
         type_info["gob_type"] = get_gob_type(type_info["type"])
     for value in type_info.values():
         # Recurse into type info to add type info for each "type" attribute

--- a/tests/gobcore/typesystem/test_typesystem.py
+++ b/tests/gobcore/typesystem/test_typesystem.py
@@ -6,12 +6,12 @@ from gobcore.typesystem import enhance_type_info, get_gob_type_from_info
 
 
 class TestTypesystem(TestCase):
-   
+
     @patch('gobcore.typesystem.get_gob_type')
     def test_get_modifications(self, mock_get_gob_type):
         self.assertEqual([], get_modifications(None, 'data', 'model'), 'Should return empty list when model is None')
         self.assertEqual([], get_modifications('entity', None, 'model'), 'Should return empty list when data is None')
-        
+
         model = {
             'field1': {
                 'type': 'the type',
@@ -20,23 +20,23 @@ class TestTypesystem(TestCase):
                 'type': 'field2 type',
             }
         }
-        
+
         entity = type('MockEntity', (object,), {
             'field1': 'oldField1value',
             'field2': 'oldField2value',
         })
-        
+
         data = {
             'field1': 'newField1value',
             'field2': 'oldField2value',
         }
-        
+
         expected_result = [
             {'key': 'field1', 'old_value': 'oldField1value', 'new_value': 'newField1value'},
         ]
-        
+
         mock_get_gob_type.return_value.from_value = lambda x, **kwargs: x
-        
+
         self.assertEqual(expected_result, get_modifications(entity, data, model))
 
     @patch('gobcore.typesystem.get_gob_type')
@@ -69,7 +69,7 @@ class TestTypesystem(TestCase):
             'k2': type('MockGobType', (object,), {'to_value': 'k2value'}),
             'k3': type('MockGobType', (object,), {'to_value': 'k3value'}),
         }
-        
+
         self.assertEqual({
             'k1': 'k1value',
             'k2': 'k2value',
@@ -113,6 +113,16 @@ class TestTypesystem(TestCase):
         }
         enhance_type_info(type_info)
         self.assertEqual(type_info['some key']['secure']['attr']['gob_type'], GOB.String)
+
+        type_info = {
+            'type': {
+                'code': {
+                    'type': "GOB.String"
+                }
+            }
+        }
+        enhance_type_info(type_info)
+        self.assertEqual(type_info['type']['code']['gob_type'], GOB.String)
 
     def test_gob_type_from_info(self):
         type_info = {


### PR DESCRIPTION
See https://github.com/Amsterdam/amsterdam-schema/blob/master/datasets/brk2/kadastralesubjecten/v1.0.0.json

```json
      "woonadres": {
        "auth": "BRK/RSN",
        "type": "object",
        "properties": {
          "type": {
            "type": "string",
            "description": "Woonlocatietype: 0: geen, 1: binnenland, 2: buitenland "
          },
```