### PR TITLE
legacy_attributes no longer obligatory for Amsterdam schema models (B…

### DIFF
--- a/gobcore/model/__init__.py
+++ b/gobcore/model/__init__.py
@@ -105,10 +105,9 @@ class GOBModel(UserDict):
 
             # GOB API.
             if cls.legacy_mode:
-                if 'schema' in collection and 'legacy_attributes' not in collection:
-                    raise GOBException(
-                        f"Expected 'legacy_attributes' to be defined for {catalog_name} {entity_name}")
-                collection['attributes'] = collection.get('legacy_attributes', collection['attributes'])
+                if 'schema' in collection and 'legacy_attributes' in collection:
+                    collection['attributes'] = collection.get(
+                        'legacy_attributes', collection['attributes'])
 
             state_attributes = STATE_FIELDS if cls.has_states(catalog_name, entity_name) else {}
             all_attributes = {

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3246,8 +3246,7 @@
           "tableId": "kadastraleobjecten",
           "version": "1.0.0",
           "entity_id": "identificatie"
-        },
-        "legacy_attributes": {}
+        }
       },
       "kadastralesubjecten": {
         "version": "0.1",
@@ -3258,8 +3257,7 @@
           "tableId": "kadastralesubjecten",
           "version": "1.0.0",
           "entity_id": "identificatie"
-        },
-        "legacy_attributes": {}
+        }
       }
     }
   },

--- a/tests/gobcore/model/test_model.py
+++ b/tests/gobcore/model/test_model.py
@@ -458,14 +458,3 @@ class TestLegacyModel(TestCase):
         with self.assertRaisesRegex(
                 Exception, "Tried to initialise model with different legacy setting"):
             GOBModel()
-
-    def test_init_legacy_attributes_not_set_for_schema(self):
-        # Prepare object. Remove legacy_attributes
-        data = self.model.data
-        data['nap']['collections']['peilmerken']['attributes'] = data[
-            'nap']['collections']['peilmerken']['legacy_attributes']
-        del data['nap']['collections']['peilmerken']['legacy_attributes']
-
-        with self.assertRaisesRegex(
-                GOBException, "Expected 'legacy_attributes' to be defined for nap peilmerken"):
-            self.model._init_catalog(data['nap'])


### PR DESCRIPTION
…RK2).