### PR TITLE
Remove hardcoded 'mode' attribute from run_as_standalone and replace with generic solution

### DIFF
--- a/gobcore/message_broker/typing.py
+++ b/gobcore/message_broker/typing.py
@@ -38,7 +38,11 @@ class OwnThread(TypedDict, total=False):
     own_thread: bool
 
 
-class Service(Exchange, Queue, Key, Handler, Logger, Report, OwnThread):
+class PassArgsStandalone(TypedDict):
+    pass_args_standalone: list[str]
+
+
+class Service(Exchange, Queue, Key, Handler, Logger, Report, OwnThread, PassArgsStandalone):
     pass
 
 

--- a/tests/gobcore/test_standalone.py
+++ b/tests/gobcore/test_standalone.py
@@ -47,6 +47,7 @@ class TestStandalone:
         mock_handler = Mock(return_value={})
         servicedefinition = get_servicedefinition_fixture(mock_handler, "import")
         servicedefinition["import"]["logger"] = "the logger"
+        servicedefinition["import"]["pass_args_standalone"] = ["mode"]
 
         message_in = {'header': {'catalogue': 'test_catalogue', 'collection': None, 'entity': None, 'attribute': None,
                                  'application': None, 'mode': 'full'}}
@@ -154,7 +155,7 @@ class TestStandalone:
         ])
         args.message_result_path = result_path
 
-        message = _build_message(args)
+        message = _build_message(args, [])
         assert message["header"]["catalogue"] == "nap"
         assert message["header"]["collection"] == "peilmerken"
         assert message["header"]["source"] == "AMSBI"
@@ -163,6 +164,6 @@ class TestStandalone:
         args = arg_parser.parse_args([
             "import", "--catalogue", "test_catalogue"
         ])
-        message = _build_message(args)
+        message = _build_message(args, [])
         assert message["header"]["catalogue"] == "test_catalogue"
         assert message["header"]["collection"] is None


### PR DESCRIPTION
Need to add more parameters in prepare. Extra parameters such as 'mode' should be configured in the SERVICE_DEFINITIONs

⚠️ **NOTE: BREAKING CHANGE for services that accept the 'mode' parameter**
I will update Import and Upload with the new core version once this one is merged and released.