### PR TITLE
Replace cx_Oracle with oracledb package

### DIFF
--- a/gobcore/datastore/oracle.py
+++ b/gobcore/datastore/oracle.py
@@ -2,7 +2,7 @@ from typing import List
 
 import re
 import os
-import cx_Oracle
+import oracledb
 import tempfile
 import shutil
 
@@ -104,7 +104,7 @@ class OracleDatastore(SqlDatastore):
     def connect(self):
         """Connect to the datasource
 
-        The cx_Oracle library is used to connect to the data source for databases
+        The oracledb library is used to connect to the data source for databases
 
         :return: a connection to the given database
         """
@@ -115,7 +115,7 @@ class OracleDatastore(SqlDatastore):
             database, username, password, port, host = [str(self.connection_config[k]) for k in items]
             self.user = f"({username}@{database})"
             dsn = self._get_dsn(host, port, database)
-            self.connection = cx_Oracle.Connection(user=username, password=password, dsn=dsn)
+            self.connection = oracledb.Connection(user=username, password=password, dsn=dsn)
         except KeyError as e:
             raise GOBException(f'Missing configuration for source {self.connection_config["name"]}. Error: {e}')
 
@@ -125,8 +125,7 @@ class OracleDatastore(SqlDatastore):
             self.connection = None
 
     def _makedict(self, cursor):
-        """Convert cx_oracle query result to be a dictionary
-        """
+        """Convert query result to be a dictionary."""
         cols = [d[0].lower() for d in cursor.description]
 
         def createrow(*args):
@@ -135,13 +134,14 @@ class OracleDatastore(SqlDatastore):
         return createrow
 
     def _output_type_handler(self, cursor, name, defaultType, size, precision, scale):
-        if defaultType == cx_Oracle.CLOB:
-            return cursor.var(cx_Oracle.LONG_STRING, arraysize=cursor.arraysize)
+        if defaultType == oracledb.CLOB:
+            return cursor.var(oracledb.LONG_STRING, arraysize=cursor.arraysize)
 
     def query(self, query, **kwargs):
-        """Reads from the database
+        """
+        Reads from the database.
 
-        The cx_Oracle library is used to connect to the data source for databases
+        The oracledb library is used to connect to the data source for databases
 
         :return: a list of data
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cryptography==38.0.4
-cx-Oracle~=8.3.0
 flake8==6.0.0
 GDAL==${LIBGDAL_VERSION}
 GeoAlchemy2==0.12.5
@@ -7,6 +6,7 @@ geomet==1.0.0
 ijson==3.1.4
 munch==2.5.0
 openpyxl==3.0.10
+oracledb~=1.2.1
 pandas==1.5.2
 paramiko==2.12.0
 pika==1.3.1

--- a/tests/gobcore/datastore/test_oracle.py
+++ b/tests/gobcore/datastore/test_oracle.py
@@ -1,10 +1,10 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from gobcore.datastore.oracle import DSN_FAILOVER_ADDRESS_TEMPLATE, DSN_FAILOVER_TEMPLATE, OracleDatastore, GOBException
+from gobcore.datastore.oracle import DSN_FAILOVER_ADDRESS_TEMPLATE, OracleDatastore, GOBException
 
 
-class MockConnection():
+class MockConnection:
     class CursorObj:
         def __init__(self, result):
             self.result = result
@@ -91,8 +91,8 @@ class TestOracleDatastore(TestCase):
         self.assertEqual(exp_res, OracleDatastore._get_dsn(**args))
 
 
-    @patch("gobcore.datastore.oracle.cx_Oracle")
-    def test_connect(self, mock_cx_oracle):
+    @patch("gobcore.datastore.oracle.oracledb")
+    def test_connect(self, mock_oracledb):
         config = {
             'username': 'user',
             'database': 'db',
@@ -102,7 +102,7 @@ class TestOracleDatastore(TestCase):
             'name': 'configname',
         }
 
-        mock_cx_oracle.Connection.return_value = {"connected": True}
+        mock_oracledb.Connection.return_value = {"connected": True}
         store = OracleDatastore(config)
         store.connect()
         self.assertEqual("(user@db)", store.user)
@@ -112,7 +112,7 @@ class TestOracleDatastore(TestCase):
         dsn = '(DESCRIPTION=(FAILOVER=off)(LOAD_BALANCE=off)(CONNECT_TIMEOUT=3)(RETRY_COUNT=3)' \
                   f'(ADDRESS_LIST={"".join(address_list)})' \
                   '(CONNECT_DATA=(SERVICE_NAME=db)))'
-        mock_cx_oracle.Connection.assert_called_with(user='user', password='pw', dsn = dsn)
+        mock_oracledb.Connection.assert_called_with(user='user', password='pw', dsn = dsn)
 
         config = {
             'username': 'user',
@@ -150,8 +150,8 @@ class TestOracleDatastore(TestCase):
         }, createrowfunc(*args))
 
     @patch("gobcore.datastore.oracle.OracleDatastore.get_url", MagicMock())
-    @patch('gobcore.datastore.oracle.cx_Oracle.CLOB', "CLOB")
-    @patch('gobcore.datastore.oracle.cx_Oracle.LONG_STRING', "LONG_STRING")
+    @patch('gobcore.datastore.oracle.oracledb.CLOB', "CLOB")
+    @patch('gobcore.datastore.oracle.oracledb.LONG_STRING', "LONG_STRING")
     def test_output_type_handler(self):
         cursor = type('Cursor', (object,), {'arraysize': 20, 'var': lambda x, arraysize: x + '_' + str(arraysize)})
         store = OracleDatastore({}, {})


### PR DESCRIPTION
WIth this new oracledb package, client libraries are not necessary anymore.

- https://python-oracledb.readthedocs.io/en/latest/user_guide/introduction.html#python-oracledb-thin-mode-architecture
- https://python-oracledb.readthedocs.io/en/latest/user_guide/appendix_c.html#upgrading-from-cx-oracle-8-3-to-python-oracledb