### PR TITLE
pytest-cov has been replaced by coverage.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.7"
 
 services:
   test:
+    container_name: gobcore
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+coverage~=7.0.1
 cryptography==38.0.4
-flake8==6.0.0
+flake8~=6.0.0
 GDAL==${LIBGDAL_VERSION}
 GeoAlchemy2==0.12.5
 geomet==1.0.0
@@ -12,12 +13,11 @@ paramiko==2.12.0
 pika==0.13.1
 psycopg2==2.9.5
 pycryptodome==3.16.0
-pydantic==1.10.2
+pydantic~=1.10.3
 pydash==5.1.2
 PyJWT==2.6.0
 pyodbc==4.0.35
 pytest==7.2.0
-pytest-cov==4.0.0
 python-dateutil==2.8.2
 python-swiftclient==4.1.0
 requests==2.28.1


### PR DESCRIPTION
- Package `pytest-cov` has been replaced by `coverage`
- Relax version constraints of `flake8` and `pydantic`
- `docker-compose.yml`: configure linux/amd64 platform image