### PR TITLE
Initialise thick mode for oracle datastore

### DIFF
--- a/gobcore/datastore/oracle.py
+++ b/gobcore/datastore/oracle.py
@@ -56,6 +56,9 @@ class OracleDatastore(SqlDatastore):
             f.write(ORACLE_CONFIG)
         os.environ['TNS_ADMIN'] = self.oracle_config_dir
 
+        oracledb.init_oracle_client()
+        assert not oracledb.is_thin_mode(), "Oracle Thick mode is required"
+
     def __del__(self):
         shutil.rmtree(self.oracle_config_dir)
 

--- a/tests/gobcore/datastore/test_oracle.py
+++ b/tests/gobcore/datastore/test_oracle.py
@@ -26,8 +26,22 @@ class MockConnection:
         return self.cursor_obj
 
 
+@patch("gobcore.datastore.oracle.oracledb.is_thin_mode", MagicMock(return_value=False))
+@patch("gobcore.datastore.oracle.oracledb.init_oracle_client", MagicMock())
 @patch("gobcore.datastore.oracle.SqlDatastore", MagicMock)
 class TestOracleDatastore(TestCase):
+
+    @patch("gobcore.datastore.oracle.oracledb")
+    def test_init(self, mock_oracledb):
+        config = {
+            'username': "username",
+            'password': "password",
+            'host': "host",
+            'port': 1234,
+            'database': 'SID'
+        }
+        OracleDatastore(config)
+        mock_oracledb.init_oracle_client.assert_called()
 
     def test_get_url(self):
         # Leave Oracle SID as it is


### PR DESCRIPTION
We need to use the thick mode of oracle, otherwise the the connection can (silently) fail.
The new oracledb library uses thin mode by default.

Client library files should still be available in the base image.