### PR TITLE
Improve ContentsReader/Writer performance

### DIFF
--- a/gobcore/message_broker/offline_contents.py
+++ b/gobcore/message_broker/offline_contents.py
@@ -5,16 +5,16 @@ This prevents the message broker from transferring large messages
 
 """
 import gc
-import json
-import ijson
+import ijson.backends.yajl2_c as ijson  # force fastest backend
 import os
 
-from gobcore.typesystem.json import GobTypeJSONEncoder
+from orjson import orjson
+
+from gobcore.typesystem.json import GobTypeORJSONEncoder
 from gobcore.utils import gettotalsizeof, get_filename, get_unique_name
 
 _MAX_CONTENTS_SIZE = 8192                   # Any message contents larger than this size is stored offline
 _CONTENTS = "contents"                      # The name of the message attribute to check for its contents
-_CONTENTS_READER = "contents_reader"        # Message contents is exposed by a ContentsReader instance
 _CONTENTS_REF = "contents_ref"              # The name of the attribute for the reference to the offloaded contents
 _MESSAGE_BROKER_FOLDER = "message_broker"   # The name of the folder where the offloaded contents are stored
 
@@ -22,48 +22,40 @@ _MESSAGE_BROKER_FOLDER = "message_broker"   # The name of the folder where the o
 class ContentsWriter:
 
     def __init__(self, destination: str = None):
-        """
-        Opens a file
-        The entities are written to the file as an array
-        """
+        """The entities are written to the file as jsonlines. (see https://jsonlines.org/)"""
         unique_name = get_unique_name()
-        destination = destination or _MESSAGE_BROKER_FOLDER
-        self.filename = get_filename(unique_name, destination)
+        self.filename = get_filename(unique_name, destination or _MESSAGE_BROKER_FOLDER)
+        self.default = GobTypeORJSONEncoder()
 
     def __enter__(self):
-        self.open()
+        if os.path.exists(self.filename):
+            raise FileExistsError(self.filename)
+
+        self.file = open(self.filename, "ab")
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
+        self.file.close()
+
         if exc_type is not None:
             os.remove(self.filename)
 
-    def open(self):
-        self.file = open(self.filename, 'w')
-        self.file.write("[")
-        self.empty = True
-
-    def write(self, entity):
+    def write(self, entity: dict, **kwargs):
         """
-        Write an entity to the file
+        Write a serialized entity to file seperated by '\n'
 
-        Separate entities with a comma
         :param entity:
+        :param kwargs: optional kwargs passed to orjson.dumps
         :return:
         """
-        if not self.empty:
-            self.file.write(",\n")
-        self.file.write(json.dumps(entity, cls=GobTypeJSONEncoder, allow_nan=False))
-        self.empty = False
-
-    def close(self):
-        """
-        Terminates the array and closes the file
-        :return:
-        """
-        self.file.write("]")
-        self.file.close()
+        self.file.write(
+            orjson.dumps(
+                entity,
+                default=self.default,
+                option=orjson.OPT_PASSTHROUGH_DATETIME | orjson.OPT_APPEND_NEWLINE,
+                **kwargs
+            )
+        )
 
 
 class ContentsReader:
@@ -76,9 +68,17 @@ class ContentsReader:
         """
         self.filename = filename
 
+    @property
+    def _has_contents(self):
+        try:
+            return os.stat(self.filename).st_size > 0
+        except OSError:
+            return False
+
     def items(self):
-        with open(self.filename, "rb") as fp:
-            yield from ijson.items(fp, prefix="item")
+        if self._has_contents:
+            with open(self.filename, "rb") as fp:
+                yield from ijson.items(fp, multiple_values=True, prefix="")
 
 
 def offload_message(msg, converter, force_offload: bool = False):
@@ -117,14 +117,17 @@ def load_message(msg, converter, params):
     :return:
     """
     unique_name = None
+
     if _CONTENTS_REF in msg:
         unique_name = msg[_CONTENTS_REF]
         filename = get_filename(unique_name, _MESSAGE_BROKER_FOLDER)
+
         if params['stream_contents']:
             msg[_CONTENTS] = ContentsReader(filename).items()
         else:
             with open(filename, 'r') as file:
                 msg[_CONTENTS] = converter(file.read())
+
         del msg[_CONTENTS_REF]
     return msg, unique_name
 
@@ -138,10 +141,6 @@ def end_message(msg, unique_name):
     :return: None
     """
     if unique_name:
-        reader = msg.get(_CONTENTS_READER)
-        if reader is not None:
-            reader.close()
-
         filename = get_filename(unique_name, _MESSAGE_BROKER_FOLDER)
         try:
             os.remove(filename)
@@ -149,6 +148,5 @@ def end_message(msg, unique_name):
             print(f"Remove failed ({str(e)})", filename)
 
     # Clear message and run garbage collection
-    for key in list(msg.keys()):
-        del msg[key]
+    msg.clear()
     gc.collect()

--- a/gobcore/typesystem/json.py
+++ b/gobcore/typesystem/json.py
@@ -3,6 +3,8 @@ import decimal
 import json
 import enum
 
+from orjson import orjson
+
 from gobcore.typesystem.gob_types import GOBType
 
 
@@ -40,3 +42,23 @@ class GobTypeJSONEncoder(json.JSONEncoder):
             return str(obj.value)
 
         return super().default(obj)
+
+
+class GobTypeORJSONEncoder:
+
+    def __call__(self, obj):  # noqa: C901 (Function is too complex)
+        if isinstance(obj, GOBType):
+            return orjson.loads(obj.json)
+
+        elif type(obj) is datetime.date:
+            return obj.isoformat()
+
+        elif type(obj) is datetime.datetime:
+            # force YYYY-MM-DDTHH:MM:SS.ffffff
+            return obj.isoformat(timespec="microseconds")
+
+        elif isinstance(obj, decimal.Decimal):
+            return str(obj)
+
+        else:
+            raise TypeError(type(obj))

--- a/gobcore/utils.py
+++ b/gobcore/utils.py
@@ -64,18 +64,23 @@ class ProgressTicker:
         """Progress ticker ended."""
         print(f"End {self._name} - {self._count}")
 
-    def _report(self):
-        if self._count % self._report_interval == 0:
-            print(f"{self._name} - {self._count}")
-
     def tick(self):
-        """Count and print progress message when count is a multiple of report_interval."""
-        self._count += 1
-        self._report()
+        """Count 1 and print progress message when count is a multiple of report_interval."""
+        self.ticks(1)
 
-    def ticks(self, count: int):
-        self._count += count
-        self._report()
+    def ticks(self, ticks: int):
+        """Count `ticks` and print progress message when count is bigger or equal to a multiple of report_interval."""
+        n_reports = ticks // self._report_interval or 1  # always loop once
+        temp_counter = self._count
+
+        for _ in range(n_reports):
+            next_interval = temp_counter + self._report_interval - temp_counter % self._report_interval
+
+            if self._count + ticks >= next_interval:
+                temp_counter = next_interval
+                print(f"{self._name} - {next_interval:,}")
+
+        self._count += ticks
 
 
 def get_hostname() -> str:

--- a/gobcore/utils.py
+++ b/gobcore/utils.py
@@ -64,11 +64,18 @@ class ProgressTicker:
         """Progress ticker ended."""
         print(f"End {self._name} - {self._count}")
 
+    def _report(self):
+        if self._count % self._report_interval == 0:
+            print(f"{self._name} - {self._count}")
+
     def tick(self):
         """Count and print progress message when count is a multiple of report_interval."""
         self._count += 1
-        if self._count % self._report_interval == 0:
-            print(f"{self._name} - {self._count}")
+        self._report()
+
+    def ticks(self, count: int):
+        self._count += count
+        self._report()
 
 
 def get_hostname() -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ ijson~=3.2.0
 munch==2.5.0
 openpyxl~=3.1.0
 oracledb~=1.2.1
+orjson~=3.8.3
 pandas~=1.5.3
 paramiko==2.12.0
 pika==0.13.1

--- a/tests/gobcore/test_utils.py
+++ b/tests/gobcore/test_utils.py
@@ -45,6 +45,18 @@ class TestProgressTicker(TestCase):
             else:
                 mock_print.assert_not_called()
 
+    @patch("builtins.print")
+    def test_ticks(self, mock_print):
+        with self.ticker:
+            self.ticker.ticks(10)
+
+            mock_print.assert_called_once()
+            assert self.ticker._count == 10
+
+            self.ticker.ticks(5)
+            mock_print.assert_called_with(f'TickerName - 15')
+            assert self.ticker._count == 15
+
 
 class TestUtilFunctions(TestCase):
 

--- a/tests/gobcore/test_utils.py
+++ b/tests/gobcore/test_utils.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, call
 
 from tests.gobcore.fixtures import get_service_fixture
 
@@ -54,8 +54,20 @@ class TestProgressTicker(TestCase):
             assert self.ticker._count == 10
 
             self.ticker.ticks(5)
-            mock_print.assert_called_with(f'TickerName - 15')
+            mock_print.assert_called_with("TickerName - 15")
             assert self.ticker._count == 15
+
+            self.ticker.ticks(32)
+            mock_print.assert_has_calls([
+                call("Start TickerName"),
+                call("TickerName - 15"),
+                call("TickerName - 30"),
+                call("TickerName - 45")
+            ])
+            assert self.ticker._count == 47
+
+            self.ticker.ticks(1000)
+            mock_print.assert_called_with("TickerName - 1,035")
 
 
 class TestUtilFunctions(TestCase):


### PR DESCRIPTION
- Update ContentsReader and ContentsWriter
  - Use orjson package: fast python json module replacement, same functionality
  - write jsonlines (https://jsonlines.org)
  - use bytes reading/writing mode (orjson/ijson take care of encoding/decoding)
- Add `ticks` method to ProgressTicker: allow progress of > 1 