### PR TITLE
BRK2 stukdeel, aantekeningenrechten and aantekeningenkadastraleobjecten.

### DIFF
--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3293,8 +3293,45 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "tenaamstellingen",
-          "version": "1.0.1",
+          "version": "1.1.0",
           "entity_id": "neuron_id",
+          "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
+        }
+      },
+      "stukdelen": {
+        "version": "0.1",
+        "abbreviation": "SDL",
+        "entity_id": "identificatie",
+        "schema": {
+          "datasetId": "brk2",
+          "tableId": "stukdelen",
+          "version": "1.0.0",
+          "entity_id": "identificatie",
+          "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
+        }
+      },
+      "aantekeningenrechten": {
+        "version": "0.1",
+        "abbreviation": "ART",
+        "entity_id": "identificatie",
+        "schema": {
+          "datasetId": "brk2",
+          "tableId": "aantekeningenrechten",
+          "version": "1.0.0",
+          "entity_id": "identificatie",
+          "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
+        }
+      },
+      "aantekeningenkadastraleobjecten": {
+        "version": "0.1",
+        "abbreviation": "AKT",
+        "entity_id": "identificatie",
+        "has_states": true,
+        "schema": {
+          "datasetId": "brk2",
+          "tableId": "aantekeningenkadastraleobjecten",
+          "version": "1.0.0",
+          "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }
       }

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3281,7 +3281,7 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "zakelijkerechten",
-          "version": "1.0.0",
+          "version": "1.1.0",
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }

--- a/gobcore/model/name_compressor.py
+++ b/gobcore/model/name_compressor.py
@@ -1,25 +1,32 @@
 """Shorten table names."""
 
 
-_CONVERSIONS = {
-    "is_bron_voor_aantekening_kadastraal_object": "bron_kad_obj",
-    "ontstaan_uit_appartementsrechtsplitsing_vve": "ontst_apprechtsplit_vve",
-    "betrokken_bij_appartementsrechtsplitsing_vve": "betr_apprechtsplit_vve",
-    "heeft_een_relatie_met": "hft_rel_mt",
-    "heeft_betrekking_op": "hft_btrk_p",
-    "is_onderdeel_van": "ondrdl_vn",
-    "aangeduid_door": "angdd_dr",
-    "wordt_uitgeoefend_in": "uitgoef_in",
-    "commerciele_vestiging": "comm_vstgng",
-    "maatschappelijke_activiteit": "maatsch_act",
-    "heeft_sbi_activiteiten": "heeft_sbi_act",
-    "refereert_aan_meetbouten_referentiepunten": "meetbouten_refpnt_rft_aan",
-    "betrokken_bij_brk_zakelijke_rechten": "betrokken_bij_brk_zrt",
-    "is_beperkt_tot_brk_tenaamstellingen": "is_beperkt_tot_brk_tng",
-    "ontstaan_uit_brk_zakelijke_rechten": "ontstaan_uit_brk_zrt",
-    "betrokken_samenwerkingsverband_brk_subject": "betr_samenwerkverband_brk_sjt",
-    "betrokken_gorzen_en_aanwassen_brk_subject": "betr_gorzen_aanwassen_brk_sjt",
-}
+from collections import OrderedDict
+
+_CONVERSIONS = OrderedDict(
+    [
+        ("is_bron_voor_aantekening_kadastraal_object", "bron_kad_obj"),
+        ("ontstaan_uit_appartementsrechtsplitsing_vve", "ontst_apprechtsplit_vve"),
+        ("betrokken_bij_appartementsrechtsplitsing_vve", "betr_apprechtsplit_vve"),
+        ("heeft_een_relatie_met", "hft_rel_mt"),
+        ("heeft_betrekking_op", "hft_btrk_p"),
+        ("is_onderdeel_van", "ondrdl_vn"),
+        ("aangeduid_door", "angdd_dr"),
+        ("wordt_uitgeoefend_in", "uitgoef_in"),
+        ("commerciele_vestiging", "comm_vstgng"),
+        ("maatschappelijke_activiteit", "maatsch_act"),
+        ("heeft_sbi_activiteiten", "heeft_sbi_act"),
+        ("refereert_aan_meetbouten_referentiepunten", "meetbouten_refpnt_rft_aan"),
+        ("betrokken_bij_brk_zakelijke_rechten", "betrokken_bij_brk_zrt"),
+        ("is_beperkt_tot_brk_tenaamstellingen", "is_beperkt_tot_brk_tng"),
+        ("ontstaan_uit_brk_zakelijke_rechten", "ontstaan_uit_brk_zrt"),
+        ("betrokken_samenwerkingsverband_brk_subject", "betr_samenwerkverband_brk_sjt"),
+        ("betrokken_gorzen_en_aanwassen_brk_subject", "betr_gorzen_aanwassen_brk_sjt"),
+        ("is_bron_voor_brk_aantekening_kadastraal_object", "is_bron_voor_brk_akt"),
+        ("_hft_btrk_p__brk_kadastraal_object", "hft_btrk_op_brk_kot"),
+        ("is_bron_voor_brk_aantekening_recht", "is_bron_voor_brk_art"),
+    ]
+)
 
 
 class NameCompressor:
@@ -27,7 +34,7 @@ class NameCompressor:
 
     For PostgreSQL the maximimum length = 63 but simply testing for this length is not enough.
 
-    The name is also used with prefixes: 'mv_' for materialized views.
+    The name is also used with prefixes: 'mv_' for materialized views, 'rel_' for relations.
     And postfixes: '_tmp' for temporary tables.
     """
 

--- a/gobcore/model/name_compressor.py
+++ b/gobcore/model/name_compressor.py
@@ -1,32 +1,28 @@
 """Shorten table names."""
 
 
-from collections import OrderedDict
-
-_CONVERSIONS = OrderedDict(
-    [
-        ("is_bron_voor_aantekening_kadastraal_object", "bron_kad_obj"),
-        ("ontstaan_uit_appartementsrechtsplitsing_vve", "ontst_apprechtsplit_vve"),
-        ("betrokken_bij_appartementsrechtsplitsing_vve", "betr_apprechtsplit_vve"),
-        ("heeft_een_relatie_met", "hft_rel_mt"),
-        ("heeft_betrekking_op", "hft_btrk_p"),
-        ("is_onderdeel_van", "ondrdl_vn"),
-        ("aangeduid_door", "angdd_dr"),
-        ("wordt_uitgeoefend_in", "uitgoef_in"),
-        ("commerciele_vestiging", "comm_vstgng"),
-        ("maatschappelijke_activiteit", "maatsch_act"),
-        ("heeft_sbi_activiteiten", "heeft_sbi_act"),
-        ("refereert_aan_meetbouten_referentiepunten", "meetbouten_refpnt_rft_aan"),
-        ("betrokken_bij_brk_zakelijke_rechten", "betrokken_bij_brk_zrt"),
-        ("is_beperkt_tot_brk_tenaamstellingen", "is_beperkt_tot_brk_tng"),
-        ("ontstaan_uit_brk_zakelijke_rechten", "ontstaan_uit_brk_zrt"),
-        ("betrokken_samenwerkingsverband_brk_subject", "betr_samenwerkverband_brk_sjt"),
-        ("betrokken_gorzen_en_aanwassen_brk_subject", "betr_gorzen_aanwassen_brk_sjt"),
-        ("is_bron_voor_brk_aantekening_kadastraal_object", "is_bron_voor_brk_akt"),
-        ("_hft_btrk_p__brk_kadastraal_object", "hft_btrk_op_brk_kot"),
-        ("is_bron_voor_brk_aantekening_recht", "is_bron_voor_brk_art"),
-    ]
-)
+_CONVERSIONS = {
+    "is_bron_voor_aantekening_kadastraal_object": "bron_kad_obj",
+    "ontstaan_uit_appartementsrechtsplitsing_vve": "ontst_apprechtsplit_vve",
+    "betrokken_bij_appartementsrechtsplitsing_vve": "betr_apprechtsplit_vve",
+    "heeft_een_relatie_met": "hft_rel_mt",
+    "heeft_betrekking_op": "hft_btrk_p",
+    "is_onderdeel_van": "ondrdl_vn",
+    "aangeduid_door": "angdd_dr",
+    "wordt_uitgeoefend_in": "uitgoef_in",
+    "commerciele_vestiging": "comm_vstgng",
+    "maatschappelijke_activiteit": "maatsch_act",
+    "heeft_sbi_activiteiten": "heeft_sbi_act",
+    "refereert_aan_meetbouten_referentiepunten": "meetbouten_refpnt_rft_aan",
+    "betrokken_bij_brk_zakelijke_rechten": "betrokken_bij_brk_zrt",
+    "is_beperkt_tot_brk_tenaamstellingen": "is_beperkt_tot_brk_tng",
+    "ontstaan_uit_brk_zakelijke_rechten": "ontstaan_uit_brk_zrt",
+    "betrokken_samenwerkingsverband_brk_subject": "betr_samenwerkverband_brk_sjt",
+    "betrokken_gorzen_en_aanwassen_brk_subject": "betr_gorzen_aanwassen_brk_sjt",
+    "is_bron_voor_brk_aantekening_kadastraal_object": "is_bron_voor_brk_akt",
+    "_hft_btrk_p__brk_kadastraal_object": "hft_btrk_op_brk_kot",
+    "is_bron_voor_brk_aantekening_recht": "is_bron_voor_brk_art",
+}
 
 
 class NameCompressor:

--- a/gobcore/sources/gobsources.json
+++ b/gobcore/sources/gobsources.json
@@ -984,6 +984,56 @@
         "van_brk_zakelijk_recht": {
           "method": "equals",
           "destination_attribute": "identificatie"
+        },
+        "is_gebaseerd_op_brk_stukdelen": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        }
+      },
+      "stukdelen": {
+        "is_bron_voor_brk_tenaamstelling": {
+          "method": "equals",
+          "destination_attribute": "neuron_id"
+        },
+        "is_bron_voor_brk_aantekening_kadastraal_object": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        },
+        "is_bron_voor_brk_aantekening_recht": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        },
+        "is_bron_voor_brk_zakelijk_recht": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        }
+      },
+      "aantekeningenrechten": {
+        "betrokken_brk_tenaamstelling": {
+          "method": "equals",
+          "destination_attribute": "neuron_id"
+        },
+        "heeft_brk_betrokken_persoon": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        },
+        "is_gebaseerd_op_brk_stukdeel": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        }
+      },
+      "aantekeningenkadastraleobjecten": {
+        "heeft_brk_betrokken_persoon": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        },
+        "heeft_betrekking_op_brk_kadastraal_object": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        },
+        "is_gebaseerd_op_brk_stukdeel": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
         }
       }
     },

--- a/tests/gobcore/model/test_name_compressor.py
+++ b/tests/gobcore/model/test_name_compressor.py
@@ -1,10 +1,9 @@
-from collections import OrderedDict
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from gobcore.model.name_compressor import NameCompressor
 
-MOCK_CONVERSIONS = OrderedDict([("something very special", "nothing")])
+MOCK_CONVERSIONS = {"something very special": "nothing"}
 
 
 class TestNameCompressor(TestCase):

--- a/tests/gobcore/model/test_name_compressor.py
+++ b/tests/gobcore/model/test_name_compressor.py
@@ -1,24 +1,22 @@
+from collections import OrderedDict
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from gobcore.model.name_compressor import NameCompressor
 
+MOCK_CONVERSIONS = OrderedDict([("something very special", "nothing")])
 
-MOCK_CONVERSIONS = {
-    "something very special": "nothing"
-}
 
 class TestNameCompressor(TestCase):
-
-    @patch("gobcore.model.name_compressor._CONVERSIONS",)
-    def test_conversions(self, mocked_conversions):
+    @patch("gobcore.model.name_compressor._CONVERSIONS", MagicMock())
+    def test_conversions(self):
         names = [
             "",
             "is_bron_voor_aantekening_kadastraal_object",
             "betrokken_bij_appartementsrechtsplitsing_vve",
             "ontstaan_uit_appartementsrechtsplitsing_vve",
-            "some string"
-            "some"
+            "some string",
+            "some",
         ]
 
         # Don't have conversions without any profit
@@ -35,7 +33,7 @@ class TestNameCompressor(TestCase):
 
         # test for long names
         mock_print = MagicMock()
-        with patch('builtins.print', mock_print):
+        with patch("builtins.print", mock_print):
             s = "x" * NameCompressor.LONG_NAME_LENGTH
             NameCompressor.compress_name(s)
             mock_print.assert_not_called()
@@ -43,3 +41,15 @@ class TestNameCompressor(TestCase):
             s = "x" * (NameCompressor.LONG_NAME_LENGTH + 1)
             NameCompressor.compress_name(s)
             mock_print.assert_called()
+
+    def test_conversion_order(self):
+        """Test compressing order."""
+        # Table for which a single compression is sufficient.
+        single_table_name = "rel_brk_akt_brk_kot_heeft_betrekking_op_kadastraal_object"
+        single_compressed_name = "rel_brk_akt_brk_kot__hft_btrk_p__kadastraal_object"
+        self.assertEqual(NameCompressor.compress_name(single_table_name), single_compressed_name)
+
+        # Table for which a double compression is needed.
+        double_table_name = "rel_brk2_akt_brk2_kot_heeft_betrekking_op_brk_kadastraal_object"
+        double_compressed_name = "rel_brk2_akt_brk2_kot__hft_btrk_op_brk_kot_"
+        self.assertEqual(NameCompressor.compress_name(double_table_name), double_compressed_name)


### PR DESCRIPTION
BRK2 collections:

- stukdelen
- aantekeningenrechten
- aantekeningenkadastraleobjecten

`NameCompressor`: use `OrderedDict` to make sure the compressing order is consistent.