### PR TITLE
BRK2 & kadastralegemeentes, kadastralegemeentecodes & updates.

### DIFF
--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3305,7 +3305,7 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "stukdelen",
-          "version": "1.0.0",
+          "version": "1.0.1",
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3244,7 +3244,7 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "kadastraleobjecten",
-          "version": "1.0.0",
+          "version": "1.1.0",
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3334,6 +3334,30 @@
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }
+      },
+      "kadastralegemeentes": {
+        "version": "0.1",
+        "abbreviation": "KGE",
+        "entity_id": "identificatie",
+        "schema": {
+          "datasetId": "brk2",
+          "tableId": "kadastralegemeentes",
+          "version": "1.0.0",
+          "entity_id": "identificatie",
+          "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
+        }
+      },
+      "kadastralegemeentecodes": {
+        "version": "0.1",
+        "abbreviation": "KCE",
+        "entity_id": "identificatie",
+        "schema": {
+          "datasetId": "brk2",
+          "tableId": "kadastralegemeentecodes",
+          "version": "1.0.0",
+          "entity_id": "identificatie",
+          "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
+        }
       }
     }
   },

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3256,7 +3256,7 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "kadastralesubjecten",
-          "version": "1.0.0",
+          "version": "1.1.0",
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }

--- a/gobcore/model/name_compressor.py
+++ b/gobcore/model/name_compressor.py
@@ -23,6 +23,7 @@ _CONVERSIONS = {
     "_hft_btrk_p__brk_kadastraal_object": "hft_btrk_op_brk_kot",
     "is_bron_voor_brk_aantekening_recht": "is_bron_voor_brk_art",
     "__ondrdl_vn__brk_kadastrale_gemeente": "onderdeel_van_brk_kge",
+    "is_ontstaan_uit_brk_kadastraalobject": "is_ontstaan_uit_brk_kot",
 }
 
 

--- a/gobcore/model/name_compressor.py
+++ b/gobcore/model/name_compressor.py
@@ -22,6 +22,7 @@ _CONVERSIONS = {
     "is_bron_voor_brk_aantekening_kadastraal_object": "is_bron_voor_brk_akt",
     "_hft_btrk_p__brk_kadastraal_object": "hft_btrk_op_brk_kot",
     "is_bron_voor_brk_aantekening_recht": "is_bron_voor_brk_art",
+    "__ondrdl_vn__brk_kadastrale_gemeente": "onderdeel_van_brk_kge",
 }
 
 

--- a/gobcore/sources/gobsources.json
+++ b/gobcore/sources/gobsources.json
@@ -917,15 +917,15 @@
     },
     "brk2": {
       "kadastraleobjecten": {
-        "heeft_een_relatie_met_verblijfsobject": {
+        "heeft_een_relatie_met_bag_verblijfsobject": {
           "method": "equals",
           "destination_attribute": "identificatie"
         },
-        "is_ontstaan_uit_g_perceel": {
+        "is_ontstaan_uit_brk_g_perceel": {
           "method": "equals",
           "destination_attribute": "identificatie"
         },
-        "is_ontstaan_uit_kadastraalobject": {
+        "is_ontstaan_uit_brk_kadastraalobject": {
           "method": "equals",
           "destination_attribute": "identificatie"
         }

--- a/gobcore/sources/gobsources.json
+++ b/gobcore/sources/gobsources.json
@@ -1035,6 +1035,12 @@
           "method": "equals",
           "destination_attribute": "identificatie"
         }
+      },
+      "kadastralegemeentecodes": {
+        "is_onderdeel_van_brk_kadastrale_gemeente": {
+          "method": "equals",
+          "destination_attribute": "identificatie"
+        }
       }
     },
     "woz": {


### PR DESCRIPTION
BRK2:

- kadastralegemeentes v1.0.0
- kadastralegemeentecodes v1.0.0
- kadastraleobjecten v1.1.0
- stukdelen v1.0.1
- kadastralesubjecten v1.1.0