### PR TITLE
Updates for BRK2 TNG v2.0.0 (has_states).

### DIFF
--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3281,7 +3281,7 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "zakelijkerechten",
-          "version": "1.2.0",
+          "version": "1.3.0",
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }
@@ -3289,12 +3289,13 @@
       "tenaamstellingen": {
         "version": "0.1",
         "abbreviation": "TNG",
-        "entity_id": "neuron_id",
+        "entity_id": "identificatie",
+        "has_states": true,
         "schema": {
           "datasetId": "brk2",
           "tableId": "tenaamstellingen",
-          "version": "1.1.0",
-          "entity_id": "neuron_id",
+          "version": "2.0.0",
+          "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }
       },
@@ -3305,7 +3306,7 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "stukdelen",
-          "version": "1.0.2",
+          "version": "1.1.0",
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }
@@ -3317,7 +3318,7 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "aantekeningenrechten",
-          "version": "1.0.0",
+          "version": "1.1.0",
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }

--- a/gobcore/sources/gobsources.json
+++ b/gobcore/sources/gobsources.json
@@ -957,7 +957,7 @@
         },
         "is_beperkt_tot_brk_tenaamstellingen": {
           "method": "equals",
-          "destination_attribute": "neuron_id"
+          "destination_attribute": "identificatie"
         },
         "rust_op_brk_kadastraal_object": {
           "method": "equals",
@@ -993,7 +993,7 @@
       "stukdelen": {
         "is_bron_voor_brk_tenaamstelling": {
           "method": "equals",
-          "destination_attribute": "neuron_id"
+          "destination_attribute": "identificatie"
         },
         "is_bron_voor_brk_aantekening_kadastraal_object": {
           "method": "equals",
@@ -1013,7 +1013,7 @@
       "aantekeningenrechten": {
         "betrokken_brk_tenaamstelling": {
           "method": "equals",
-          "destination_attribute": "neuron_id"
+          "destination_attribute": "identificatie"
         },
         "heeft_brk_betrokken_persoon": {
           "method": "equals",


### PR DESCRIPTION
- GOB model updates
- GOB sources updates
- removed `begin_geldigheid` from BRK2 SDL
