### PR TITLE
BRK2 relates.

### DIFF
--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3281,7 +3281,7 @@
         "schema": {
           "datasetId": "brk2",
           "tableId": "zakelijkerechten",
-          "version": "1.4.0",
+          "version": "1.5.0",
           "entity_id": "identificatie",
           "base_uri": "https://raw.githubusercontent.com/Amsterdam/amsterdam-schema/brk2_active_dataset"
         }

--- a/gobcore/sources/gobsources.json
+++ b/gobcore/sources/gobsources.json
@@ -985,11 +985,6 @@
           "destination_attribute": "identificatie",
           "none_allowed": true
         },
-        "betrokken_bij_appartementsrechtsplitsing_vve": {
-          "method": "equals",
-          "destination_attribute": "identificatie",
-          "none_allowed": true
-        },
         "rust_op_brk_kadastraal_object": {
           "method": "equals",
           "destination_attribute": "identificatie"


### PR DESCRIPTION
BRK2 relates:

- KOT: aangeduid_door_brk_kadastralesectie => kadastralesecties.code
- ZRT v1.5.0: betrokkenBijAppartementsrechtsplitsingVve to string