### PR TITLE
Use Adam schema multipleOf (number type) for GOB.Decimal precision.

### DIFF
--- a/gobcore/model/amschema/model.py
+++ b/gobcore/model/amschema/model.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from decimal import Decimal
 from enum import Enum
 from typing import Literal, Optional, Union
 
@@ -13,7 +14,7 @@ class Property(ABC, BaseModel):
 
     @property
     @abstractmethod
-    def gob_type(self):  # pragma: no cover
+    def gob_type(self) -> str:  # pragma: no cover
         pass
 
     def gob_representation(self, dataset: "Dataset"):
@@ -53,6 +54,16 @@ class NumberProperty(Property):
     @property
     def gob_type(self):
         return "GOB.Decimal"
+
+    def gob_representation(self, dataset: "Dataset"):
+        """Return the GOB representation of NumberProperty."""
+        if self.multipleOf:
+            _, _, exponent = Decimal(str(self.multipleOf)).as_tuple()
+            return {
+                **super().gob_representation(dataset),
+                "precision": -exponent
+            }
+        return super().gob_representation(dataset)
 
 
 class IntegerProperty(Property):

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -1,4 +1,4 @@
-"""GOB Types
+"""GOB Types.
 
 Each possible data type in GOB is defined in this module.
 The definition includes:
@@ -12,8 +12,9 @@ todo:
 
 todo:
     think about the tight coupling with SQLAlchemy, is that what we want?
-
 """
+
+
 import datetime
 import decimal
 import json
@@ -30,7 +31,9 @@ from gobcore.model.metadata import FIELD
 
 
 class GOBType(metaclass=ABCMeta):
-    """Abstract baseclass for the GOB Types, use like follows:
+    """Abstract Base Class for GOB Types.
+
+    Use as follows:
 
         # instantiates an instance of a GOB Type (for instance String)
         #   Instantiating can only be done with a string, because the internal representation of a value is string
@@ -88,10 +91,9 @@ class GOBType(metaclass=ABCMeta):
 
     @classmethod
     def from_value_secure(cls, value, typeinfo, **kwargs):
-        """
-        A mapper around from_value to handle secure data.
+        """Mapper around cls.from_value to handle (secure) GOBType values.
 
-        The type information is used to protect the data with the right confidence level.
+        The type information is used to protect the value with the right confidence level.
 
         :param value: the value of the GOBType instance
         :param typeinfo: the GOB Model type information for the given value
@@ -153,6 +155,8 @@ class GOBType(metaclass=ABCMeta):
 
 
 class String(GOBType):
+    """GOBType class for GOB.String."""
+
     name = "String"
     sql_type = sqlalchemy.String
 
@@ -179,6 +183,8 @@ class String(GOBType):
 
 
 class Character(String):
+    """GOBType class for GOB.Character."""
+
     name = "Character"
     sql_type = sqlalchemy.CHAR
 
@@ -200,6 +206,8 @@ class Character(String):
 
 
 class Integer(String):
+    """GOBType class for GOB.Integer."""
+
     name = "Integer"
     sql_type = sqlalchemy.Integer
 
@@ -229,41 +237,48 @@ class Integer(String):
 
 
 class BigInteger(Integer):
+    """GOBType class for GOB.BigInteger."""
+
     name = "BigInteger"
     sql_type = sqlalchemy.BigInteger
 
 
 class PKInteger(Integer):
+    """GOBType class for GOB.PKInteger."""
+
     name = "PKInteger"
     is_pk = True
 
 
 class Decimal(GOBType):
+    """GOBType class for GOB.Decimal."""
+
     name = "Decimal"
     sql_type = sqlalchemy.DECIMAL
 
-    def __init__(self, value, **kwargs):  # noqa: C901
+    def __init__(self, value: Optional[str], **kwargs) -> None:  # noqa: C901
         if value == 'nan':
             value = None
         if value is not None:
             try:
                 if 'precision' in kwargs:
                     fmt = f".{kwargs['precision']}f"
-                    value = format(float(value), fmt)
+                    # Preserve Decimal precision
+                    value = str(decimal.Decimal(format(float(value), fmt)))
                 else:
-                    # Preserve Decimal format
-                    value = str(decimal.Decimal(value))
-            except (ValueError, decimal.InvalidOperation):
-                raise GOBTypeException(f"value '{value}' cannot be interpreted as Decimal")
+                    # Without precision
+                    value = str(float(value))
+            except (ValueError, decimal.InvalidOperation) as exc:
+                raise GOBTypeException(f"value '{value}' cannot be interpreted as Decimal: {exc}")
         super().__init__(value)
 
     @classmethod
     def from_value(cls, value, **kwargs):
-        """ Create a Decimal GOB Type from value and kwargs:
+        """Create a Decimal GOB Type from value and kwargs.
 
             Decimal.from_value("123.0", decimal_separator='.')
 
-        For now decemial separator is optional - setting it would make sense in import,
+        For now decimal separator is optional - setting it would make sense in import,
         but not in transfer and comparison
         """
         decimal_separator_internal = '.'
@@ -290,6 +305,8 @@ class Decimal(GOBType):
 
 
 class Boolean(GOBType):
+    """GOBType class for GOB.Boolean."""
+
     name = "Boolean"
     sql_type = sqlalchemy.Boolean
 
@@ -301,7 +318,7 @@ class Boolean(GOBType):
 
     @classmethod
     def from_value(cls, value, **kwargs):
-        """ Create a Decimal GOB Type from value and kwargs:
+        """Create a Boolean GOB Type from value and kwargs.
 
             Boolean.from_value("N", format="YN")
 
@@ -352,6 +369,8 @@ class Boolean(GOBType):
 
 
 class Date(String):
+    """GOBType class for GOB.Date."""
+
     name = "Date"
     sql_type = sqlalchemy.Date
     internal_format = "%Y-%m-%d"
@@ -390,6 +409,8 @@ class Date(String):
 
 
 class DateTime(Date):
+    """GOBType class for GOB.DateTime."""
+
     name = "DateTime"
     sql_type = sqlalchemy.DateTime
     internal_format = "%Y-%m-%dT%H:%M:%S.%f"
@@ -429,6 +450,8 @@ class DateTime(Date):
 
 
 class JSON(GOBType):
+    """GOBType class for GOB.JSON."""
+
     name = "JSON"
     sql_type = sqlalchemy.dialects.postgresql.JSONB
 
@@ -522,6 +545,8 @@ class JSON(GOBType):
 
 
 class Reference(JSON):
+    """GOBType class for GOB.Reference."""
+
     name = "Reference"
     exclude_keys = (FIELD.REFERENCE_ID, FIELD.SEQNR)  # Legacy. Old way of storing relations.
 
@@ -544,6 +569,8 @@ class Reference(JSON):
 
 
 class ManyReference(Reference):
+    """GOBType class for GOB.ManyReference."""
+
     name = "ManyReference"
 
     def __eq__(self, other, exclude_keys=(FIELD.REFERENCE_ID, FIELD.SEQNR)):
@@ -564,10 +591,14 @@ class ManyReference(Reference):
 
 
 class VeryManyReference(ManyReference):
+    """GOBType class for GOB.VeryManyReference."""
+
     name = "VeryManyReference"
 
 
 class IncompleteDate(JSON):
+    """GOBType class for GOB.IncompleteDate."""
+
     name = "IncompleteDate"
     pattern = r"^(\d{4})-(\d{2})-(\d{2})$"
 

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -16,7 +16,6 @@ todo:
 
 
 import datetime
-import decimal
 import json
 import numbers
 import re
@@ -263,12 +262,10 @@ class Decimal(GOBType):
             try:
                 if 'precision' in kwargs:
                     fmt = f".{kwargs['precision']}f"
-                    # Preserve Decimal precision
-                    value = str(decimal.Decimal(format(float(value), fmt)))
+                    value = format(float(value), fmt)
                 else:
-                    # Without precision
                     value = str(float(value))
-            except (ValueError, decimal.InvalidOperation) as exc:
+            except ValueError as exc:
                 raise GOBTypeException(f"value '{value}' cannot be interpreted as Decimal: {exc}")
         super().__init__(value)
 

--- a/tests/gobcore/model/test_schema.py
+++ b/tests/gobcore/model/test_schema.py
@@ -32,6 +32,7 @@ class TestAMSSchema(unittest.TestCase):
                     'type': 'GOB.Geo.Point'},
                 'hoogte_tov_nap': {
                     'description': 'Hoogte van het peilmerk t.o.v. NAP',
+                    'precision': 2,
                     'type': 'GOB.Decimal'
                 },
                 'identificatie': {
@@ -123,10 +124,12 @@ class TestAMSSchema(unittest.TestCase):
                 },
                 'x_coordinaat_muurvlak': {
                     'description': 'X-coördinaat muurvlak',
+                    'precision': 2,
                     'type': 'GOB.Decimal'
                 },
                 'y_coordinaat_muurvlak': {
                     'description': 'Y-coördinaat muurvlak',
+                    'precision': 2,
                     'type': 'GOB.Decimal'
                 },
             },

--- a/tests/gobcore/typesystem/test_gob_types.py
+++ b/tests/gobcore/typesystem/test_gob_types.py
@@ -132,10 +132,13 @@ class TestGobTypes(unittest.TestCase):
         self.assertEqual('null', GobType.from_value("nan").json)
         self.assertEqual('123.0', GobType.from_value(123).json)
         self.assertEqual('123.123', GobType.from_value(123.123).json)
-        # Preserve Decimal format
+        # Decimal format (no precision)
+        self.assertEqual('123.0', GobType('123').to_value)
         self.assertEqual('123.0', GobType('123.0').to_value)
-        self.assertEqual('123.00', GobType('123.00').to_value)
-        self.assertEqual('123.000', GobType('123.000').to_value)
+        self.assertEqual('123.0', GobType('123.00').to_value)
+        # Preserve Decimal format (precision).
+        self.assertEqual('123.00', GobType('123.0', precision=2).to_value)
+        self.assertEqual('123.000', GobType('123.0', precision=3).to_value)
 
         # DB output is float
         self.assertIsInstance(GobType.from_value('123').to_db, float)


### PR DESCRIPTION
Use Amsterdam schema `multipleOf` (number type) for `GOB.Decimal` precision.