### PR TITLE
Use model type_info in GOB Types.

### DIFF
--- a/gobcore/events/import_events.py
+++ b/gobcore/events/import_events.py
@@ -1,4 +1,4 @@
-"""GOB Events
+"""GOB Events.
 
 Each possible event in GOB is defined in this module.
 The definition includes:
@@ -11,11 +11,13 @@ todo: The delete and confirm actions contain too much data. Contents can be left
     See also the examples in the action classes
 """
 
+
 from abc import ABCMeta, abstractmethod
 
 from gobcore.exceptions import GOBException
 from gobcore.model import GOBModel
-from gobcore.typesystem import get_gob_type
+from gobcore.typesystem import get_gob_type_from_info
+from gobcore.typesystem.gob_types import get_kwargs_from_type_info
 
 hash_key = '_hash'
 modifications_key = 'modifications'
@@ -88,7 +90,7 @@ class ImportEvent(metaclass=ABCMeta):
             setattr(entity, key, value)
 
     def get_attribute_dict(self):
-        """Gets an dict with attributes to insert entities in bulk
+        """Return a dict with attributes to insert entities in bulk.
 
         :return:
         """
@@ -100,8 +102,10 @@ class ImportEvent(metaclass=ABCMeta):
 
         for key, value in self._data.items():
             if key not in self.skip:
-                gob_type = get_gob_type(self._model['all_fields'][key]['type'])
-                entity[key] = gob_type.from_value(value).to_db
+                type_info = self._model['all_fields'][key]
+                gob_type = get_gob_type_from_info(type_info)
+                entity[key] = gob_type.from_value(value, **get_kwargs_from_type_info(type_info)).to_db
+
         return entity
 
 

--- a/gobcore/typesystem/__init__.py
+++ b/gobcore/typesystem/__init__.py
@@ -3,13 +3,16 @@
 GOB data consists of entities with attributes, eg Meetbout = { identificatie, locatie, ... }
 The possible types for each attribute are defined in this module.
 The definition and characteristics of each type is in the gob_types module
-
 """
-import sqlalchemy
+
+
+from typing import Any, Optional
+
 import geoalchemy2
+import sqlalchemy
 
 from gobcore.exceptions import GOBException
-from gobcore.typesystem import gob_types, gob_secure_types, gob_geotypes
+from gobcore.typesystem import gob_geotypes, gob_secure_types, gob_types
 
 # The possible type definitions are imported from the gob_types module
 GOB = gob_types
@@ -76,11 +79,10 @@ _gob_postgres_sql_types_list = [
 ]
 
 
-def enhance_type_info(type_info):
-    """Enhance type info with gob types.
+def enhance_type_info(type_info: dict[str, Any]) -> None:
+    """Enhance GOBModel field type info with GOBType class.
 
-    For every type attribute a corresponding gob_type attribute is set
-    that contains the GOB type class.
+    For every "type" key a corresponding "gob_type" key is set that contains the GOBType class.
 
     :param type_info:
     :return:
@@ -88,29 +90,28 @@ def enhance_type_info(type_info):
     if type_info.get("type") and not isinstance(type_info["type"], dict):
         type_info["gob_type"] = get_gob_type(type_info["type"])
     for value in type_info.values():
-        # Recurse into type info to add type info for each "type" attribute
+        # Recurse into GOB.JSON values to add a "gob_type" key for each attribute dict with a "type" key
         if isinstance(value, dict):
             enhance_type_info(value)
 
 
-def get_gob_type_from_info(typeinfo):
-    """
-    Return the GOB type for the given type info
+def get_gob_type_from_info(type_info):
+    """Return the GOBType class for the given GOBModel type info.
+
     The type info is enhanced (adding GOB types to it)
-    :param typeinfo:
+    :param type_info:
     :return:
     """
-    if not typeinfo.get("gob_type"):
-        enhance_type_info(typeinfo)
-    return typeinfo["gob_type"]
+    if not type_info.get("gob_type"):
+        enhance_type_info(type_info)
+    return type_info["gob_type"]
 
 
 def get_gob_type(name):
-    """
-    Get the type definition for a given type name
+    """Return GOBType class for a given GOBModel type name.
 
     Example:
-        get_gob_type("string") => GOBType:String
+        get_gob_type("GOB.String") => GOBType:String class
 
     :param name:
     :return: the type definition (class) for the given type name
@@ -119,12 +120,12 @@ def get_gob_type(name):
 
 
 def fully_qualified_type_name(gob_type):
+    """Return the fully qualified type name of GOBType class."""
     return f"GOB.{gob_type.name}"
 
 
 def is_gob_reference_type(type_name):
-    """
-    Tels if type_name is the name of a GOB Reference type
+    """Tell if type_name is the name of a GOB Reference type.
 
     :param type_name:
     :return:
@@ -133,7 +134,7 @@ def is_gob_reference_type(type_name):
                          for t in [GOB.Reference, GOB.ManyReference, GOB.VeryManyReference]]
 
 
-def is_gob_geo_type(name):
+def is_gob_geo_type(name) -> bool:
     """Returns a boolean value
 
     :param name:
@@ -172,27 +173,30 @@ def get_gob_type_from_sql_type(sql_type):
     raise GOBException(f"No GOBType found for SQLType: {sql_type}")
 
 
-def get_modifications(entity, data, model):     # noqa: C901
-    """Get a list of modifications
+def get_modifications(
+    entity: Optional[Any], data: Optional[dict[str, Any]], model: dict[str, Any]
+) -> list[dict[str, str]]:  # noqa: C901
+    """Return a list with compare result modifications.
 
-    :param entity: an object with named attributes with values
-    :param data: a dict with named keys and changed values
-    :param model: a dict describing the model of both entity and data
+    :param entity: a SQLAlchemy object with named attributes with old values
+    :param data: a dict with named keys and changed source values
+    :param model: a dict describing the model of both entity and data (collection["all_fields"])
 
     :return: a list of modification-dicts: `{'key': "fieldname", 'old_value': "old_value", 'new_value': "new_value"}`
     """
-    modifications = []
+    modifications: list[dict[str, str]] = []
 
     if entity is None or data is None:
         return modifications
 
-    for field_name, field in model.items():
-        gob_type = get_gob_type(field['type'])
-        old_value = gob_type.from_value(getattr(entity, field_name))
+    for field_name, field_info in model.items():
+        gob_type = get_gob_type_from_info(field_info)
+        field_kwargs = gob_types.get_kwargs_from_type_info(field_info)
+        old_value = gob_type.from_value(getattr(entity, field_name), **field_kwargs)
 
         # Try to get the new value from the data, if missing, skip this field
         try:
-            new_value = gob_type.from_value(data[field_name])
+            new_value = gob_type.from_value(data[field_name], **field_kwargs)
         except KeyError:
             continue
 
@@ -203,7 +207,7 @@ def get_modifications(entity, data, model):     # noqa: C901
 
 
 def get_value(entity):
-    """Get a dictionatry with python objects of an entity of GOBTypes
+    """Return a dictionary with Python objects of an entity of GOBTypes.
 
     :param entity: an object with named attributes with values
 

--- a/gobcore/typesystem/__init__.py
+++ b/gobcore/typesystem/__init__.py
@@ -6,7 +6,7 @@ The definition and characteristics of each type is in the gob_types module
 """
 
 
-from typing import Any, Optional
+from typing import Any, Optional, TypedDict
 
 import geoalchemy2
 import sqlalchemy
@@ -173,9 +173,17 @@ def get_gob_type_from_sql_type(sql_type):
     raise GOBException(f"No GOBType found for SQLType: {sql_type}")
 
 
+class Modification(TypedDict):
+    """Modification dictionary."""
+
+    key: str
+    old_value: gob_types.GOBType
+    new_value: gob_types.GOBType
+
+
 def get_modifications(
     entity: Optional[Any], data: Optional[dict[str, Any]], model: dict[str, Any]
-) -> list[dict[str, str]]:  # noqa: C901
+) -> list[Modification]:
     """Return a list with compare result modifications.
 
     :param entity: a SQLAlchemy object with named attributes with old values
@@ -184,7 +192,7 @@ def get_modifications(
 
     :return: a list of modification-dicts: `{'key': "fieldname", 'old_value': "old_value", 'new_value': "new_value"}`
     """
-    modifications: list[dict[str, str]] = []
+    modifications: list[Modification] = []
 
     if entity is None or data is None:
         return modifications

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -16,6 +16,7 @@ todo:
 
 
 import datetime
+import decimal
 import json
 import numbers
 import re
@@ -260,12 +261,14 @@ class Decimal(GOBType):
             value = None
         if value is not None:
             try:
-                if 'precision' in kwargs:
+                if "precision" in kwargs:
+                    # Set Decimal precision
                     fmt = f".{kwargs['precision']}f"
-                    value = format(float(value), fmt)
+                    value = format(decimal.Decimal(value), fmt)
                 else:
-                    value = str(float(value))
-            except ValueError as exc:
+                    # Preserve Decimal precision
+                    value = str(decimal.Decimal(value))
+            except (ValueError, decimal.InvalidOperation) as exc:
                 raise GOBTypeException(f"value '{value}' cannot be interpreted as Decimal: {exc}")
         super().__init__(value)
 
@@ -288,13 +291,13 @@ class Decimal(GOBType):
 
     @property
     def json(self):
-        return json.dumps(float(self._string)) if self._string is not None else json.dumps(None)
+        return json.dumps(self._string) if self._string is not None else json.dumps(None)
 
     @property
     def to_db(self):
         if self._string is None:
             return None
-        return float(self._string)
+        return decimal.Decimal(self._string)
 
     @property
     def to_value(self):

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -30,7 +30,7 @@ from gobcore.exceptions import GOBTypeException
 from gobcore.model.metadata import FIELD
 
 
-def get_kwargs_from_type_info(type_info: dict[str, Any]) -> dict[str, str]:
+def get_kwargs_from_type_info(type_info: dict[str, Any]) -> dict[str, Any]:
     """Return kwargs dictionary from GOB Model field type info."""
     # Collect special keys like 'precision'.
     type_kwargs = {

--- a/gobcore/typesystem/gob_types.py
+++ b/gobcore/typesystem/gob_types.py
@@ -22,12 +22,21 @@ import numbers
 import re
 from abc import ABCMeta, abstractmethod
 from math import isnan
-from typing import Optional
+from typing import Any, Optional
 
 import sqlalchemy
 
 from gobcore.exceptions import GOBTypeException
 from gobcore.model.metadata import FIELD
+
+
+def get_kwargs_from_type_info(type_info: dict[str, Any]) -> dict[str, str]:
+    """Return kwargs dictionary from GOB Model field type info."""
+    # Collect special keys like 'precision'.
+    type_kwargs = {
+        key: value for key, value in type_info.items() if key not in ["type", "gob_type", "description", "ref"]
+    }
+    return type_kwargs
 
 
 class GOBType(metaclass=ABCMeta):
@@ -90,25 +99,29 @@ class GOBType(metaclass=ABCMeta):
         return self._string == str(other) if isinstance(other, GOBType) else self._string == other
 
     @classmethod
-    def from_value_secure(cls, value, typeinfo, **kwargs):
+    def from_value_secure(cls, value, type_info, **kwargs):
         """Mapper around cls.from_value to handle (secure) GOBType values.
 
         The type information is used to protect the value with the right confidence level.
 
         :param value: the value of the GOBType instance
-        :param typeinfo: the GOB Model type information for the given value
+        :param type_info: the GOB Model field type information for the given value
         :param kwargs:
         :return: GOBType
         """
         if cls.is_secure:
             # Secure types require a confidence level
-            kwargs["level"] = typeinfo["level"]
+            kwargs["level"] = type_info["level"]
+        # GOB.JSON
         if isinstance(value, dict):
             # Attributes are either defined in the 'secure' dict or the 'attributes' dict. Pass either.
-            if typeinfo.get("secure"):
-                kwargs["secure"] = typeinfo["secure"]
-            elif typeinfo.get("attributes"):
-                kwargs["attributes"] = typeinfo["attributes"]
+            if type_info.get("secure"):
+                kwargs["secure"] = type_info["secure"]
+            elif type_info.get("attributes"):
+                kwargs["attributes"] = type_info["attributes"]
+        else:
+            # Update kwargs with GOB Model field type info dict.
+            kwargs = get_kwargs_from_type_info(type_info) | kwargs
         return cls.from_value(value, **kwargs)
 
     @classmethod
@@ -124,7 +137,7 @@ class GOBType(metaclass=ABCMeta):
     @property
     @abstractmethod
     def json(self):
-        """Json string representation of the GOBType instance
+        """JSON string representation of the GOBType instance for ContentsWriter.
 
         :return: JSON String
         """
@@ -276,7 +289,7 @@ class Decimal(GOBType):
     def from_value(cls, value, **kwargs):
         """Create a Decimal GOB Type from value and kwargs.
 
-            Decimal.from_value("123.0", decimal_separator='.')
+            Decimal.from_value("123.0", decimal_separator='.', **get_kwargs_from_type_info(type_info))
 
         For now decimal separator is optional - setting it would make sense in import,
         but not in transfer and comparison
@@ -491,7 +504,7 @@ class JSON(GOBType):
 
     @classmethod
     def _process_from_value(cls, value, attributes):
-        """
+        """Recurse into dict (value) to add field keys with values.
 
         :param value:
         :param attributes: Either the 'secure' dict or 'attributes' dict from the field definition
@@ -501,11 +514,10 @@ class JSON(GOBType):
             if isinstance(attr_value, dict):
                 cls._process_from_value(attr_value, attributes)
             elif attributes.get(attr):
-                attribute = attributes[attr]
-                gob_type = attribute['gob_type']
-                type_kwargs = {k: v for k, v in attribute.items()
-                               if k not in ['type', 'gob_type', 'source_mapping', 'filters']}
-                value[attr] = gob_type.from_value_secure(attr_value, attribute, **type_kwargs).to_value
+                type_info = attributes[attr]
+                type_kwargs = get_kwargs_from_type_info(type_info)
+                gob_type = type_info['gob_type']
+                value[attr] = gob_type.from_value_secure(attr_value, type_info, **type_kwargs).to_value
 
     @classmethod
     def from_value(cls, value, **kwargs):

--- a/tests/gobcore/typesystem/test_json.py
+++ b/tests/gobcore/typesystem/test_json.py
@@ -133,6 +133,8 @@ class TestORJSONEncoding(unittest.TestCase):
 
         # Decimal should be quoted
         assert self.dump({'string': Decimal.from_value("123,40", decimal_separator=',')}) == b'{"string":"123.40"}'
+        # Decimal in JSON should honor precision
+        assert self.dump({'decimal': Decimal.from_value("123", precision=2)}) == b'{"decimal":"123.00"}'
 
         # Boolean should be primitive
         assert self.dump({"string": Boolean.from_value("N", format='YN')}) == b'{"string":false}'

--- a/tests/gobcore/typesystem/test_json.py
+++ b/tests/gobcore/typesystem/test_json.py
@@ -1,16 +1,15 @@
+import datetime
+import decimal
 import enum
 import functools
 import json
 import unittest
-import datetime
-import decimal
 
 from orjson import orjson
 
 from gobcore.typesystem.gob_geotypes import Point
-from gobcore.typesystem.gob_types import String, Integer, Decimal, Boolean, JSON
+from gobcore.typesystem.gob_types import JSON, Boolean, Decimal, Integer, String
 from gobcore.typesystem.json import GobTypeJSONEncoder, GobTypeORJSONEncoder
-
 from tests.gobcore import fixtures
 
 
@@ -64,10 +63,10 @@ class TestJsonEncoding(unittest.TestCase):
         to_json = json.dumps({'string': gob_type}, cls=GobTypeJSONEncoder)
         self.assertEqual('{"string": 123}', to_json)
 
-        # Decimal should be primitive
-        gob_type = Decimal.from_value("123,4", decimal_separator=',')
-        to_json = json.dumps({'string': gob_type}, cls=GobTypeJSONEncoder)
-        self.assertEqual('{"string": 123.4}', to_json)
+        # Decimal should be quoted
+        gob_decimal = Decimal.from_value("123,4", decimal_separator=',')
+        to_json = json.dumps({'string': gob_decimal}, cls=GobTypeJSONEncoder)
+        self.assertEqual('{"string": "123.4"}', to_json)
 
         # Boolean should be primitive
         gob_type = Boolean.from_value("N", format='YN')
@@ -132,8 +131,8 @@ class TestORJSONEncoding(unittest.TestCase):
         # Integer should be primitive
         assert self.dump({'string': Integer.from_value(123)}) == b'{"string":123}'
 
-        # Decimal should be primitive
-        assert self.dump({'string': Decimal.from_value("123,4", decimal_separator=',')}) == b'{"string":123.4}'
+        # Decimal should be quoted
+        assert self.dump({'string': Decimal.from_value("123,40", decimal_separator=',')}) == b'{"string":"123.40"}'
 
         # Boolean should be primitive
         assert self.dump({"string": Boolean.from_value("N", format='YN')}) == b'{"string":false}'


### PR DESCRIPTION
Use model type info in all GOB Types.

- Honor (Amsterdam schema) model _type_info_ (field_info) kwargs in GOB Types
- Preserve GOB.Decimal precision (default)
- Use `decimal.Decimal` for:
  - Preservation of significant digits
  - Rounding Numbers