### PR TITLE
Fix sqlserver connection for driver v18

### DIFF
--- a/gobcore/datastore/sqlserver.py
+++ b/gobcore/datastore/sqlserver.py
@@ -6,7 +6,7 @@ from typing import List
 from gobcore.datastore.sql import SqlDatastore
 
 # Can be ODBC driver name or path such as /usr/local/lib/libtdsodbc.so
-SQLSERVER_ODBC_DRIVER = os.getenv('SQLSERVER_ODBC_DRIVER', 'ODBC Driver 17 for SQL Server')
+SQLSERVER_ODBC_DRIVER = os.getenv('SQLSERVER_ODBC_DRIVER', 'ODBC Driver 18 for SQL Server')
 
 
 class SqlServerDatastore(SqlDatastore):
@@ -15,11 +15,14 @@ class SqlServerDatastore(SqlDatastore):
         super(SqlServerDatastore, self).__init__(connection_config, read_config)
 
     def connect(self):
-        connstring = f"DRIVER={{{SQLSERVER_ODBC_DRIVER}}};" \
-                     f"SERVER={self.connection_config['host']},{self.connection_config['port']};" \
-                     f"DATABASE={self.connection_config['database']};" \
-                     f"UID={self.connection_config['username']};" \
-                     f"PWD={self.connection_config['password']}"
+        connstring = (
+            f"DRIVER={{{SQLSERVER_ODBC_DRIVER}}};"
+            f"SERVER={self.connection_config['host']},{self.connection_config['port']};"
+            f"DATABASE={self.connection_config['database']};"
+            f"ENCRYPT=optional;"  # v18 default is yes, not supported by DECOS
+            f"UID={self.connection_config['username']};"
+            f"PWD={self.connection_config['password']}"
+        )
 
         self.connection = pyodbc.connect(connstring, autocommit=True)
 

--- a/tests/gobcore/datastore/test_sqlserver.py
+++ b/tests/gobcore/datastore/test_sqlserver.py
@@ -22,7 +22,9 @@ class TestSqlServerDatastore(TestCase):
         store.connect()
 
         self.assertEqual(mock_pyodbc.connect.return_value, store.connection)
-        mock_pyodbc.connect.assert_called_with('DRIVER={DRIVER};SERVER=HOST,PORT;DATABASE=DB;UID=USER;PWD=PASS', autocommit=True)
+
+        conn = "DRIVER={DRIVER};SERVER=HOST,PORT;DATABASE=DB;ENCRYPT=optional;UID=USER;PWD=PASS"
+        mock_pyodbc.connect.assert_called_with(conn, autocommit=True)
 
     def test_disconnect(self):
         store = SqlServerDatastore({})


### PR DESCRIPTION
Sqlserver odbc driver v18 defaults to encrypt=yes, but DECOS doesn't support that.