### PR TITLE
Use AMS Schema for entity_id and has_states.

### DIFF
--- a/gobcore/model/amschema/model.py
+++ b/gobcore/model/amschema/model.py
@@ -15,7 +15,7 @@ class Property(ABC, BaseModel):
 
     @property
     @abstractmethod
-    def gob_type(self) -> str:  # pragma: no cover
+    def gob_type(self) -> str:
         pass
 
     def gob_representation(self, dataset: "Dataset"):
@@ -217,7 +217,8 @@ class Dataset(BaseModel):
     title: str
     status: str
     version: str
-    crs: str
+    # Coördinaten in het stelsel van de Rijksdriehoeksmeting (RD)
+    crs: str = "EPSG:28992"
     owner: str
     creator: str
     publisher: str

--- a/gobcore/model/gobmodel.json
+++ b/gobcore/model/gobmodel.json
@@ -3239,49 +3239,35 @@
     "abbreviation": "BRK2",
     "collections": {
       "kadastraleobjecten": {
-        "version": "0.1",
         "abbreviation": "KOT",
-        "entity_id": "identificatie",
-        "has_states": true,
         "schema": {
           "datasetId": "brk2",
           "tableId": "kadastraleobjecten",
-          "version": "2.2.1",
-          "entity_id": "identificatie"
+          "version": "2.2.1"
         }
       },
       "kadastralesubjecten": {
-        "version": "0.1",
         "abbreviation": "SJT",
-        "entity_id": "identificatie",
         "schema": {
           "datasetId": "brk2",
           "tableId": "kadastralesubjecten",
-          "version": "1.1.0",
-          "entity_id": "identificatie"
+          "version": "1.1.0"
         }
       },
       "meta": {
-        "version": "0.1",
         "abbreviation": "META",
-        "entity_id": "id",
         "schema": {
           "datasetId": "brk2",
           "tableId": "meta",
-          "version": "1.0.0",
-          "entity_id": "id"
+          "version": "1.0.0"
         }
       },
       "zakelijkerechten": {
-        "version": "0.1",
         "abbreviation": "ZRT",
-        "entity_id": "identificatie",
-        "has_states": true,
         "schema": {
           "datasetId": "brk2",
           "tableId": "zakelijkerechten",
-          "version": "1.6.0",
-          "entity_id": "identificatie"
+          "version": "1.6.0"
         }
       },
       "tenaamstellingen": {

--- a/gobcore/model/schema.py
+++ b/gobcore/model/schema.py
@@ -1,36 +1,50 @@
+from pydash import snake_case
+
 from gobcore.model.amschema.model import Dataset, Table
 from gobcore.model.amschema.repo import AMSchemaRepository
 from gobcore.model.pydantic import Schema
-from pydash import snake_case
 
 
 class LoadSchemaException(Exception):
     pass
 
 
-def load_schema(schema: Schema):
+def _get_entity_id_from_amschema(table: Table) -> str:
+    """Return entity_id for the given table (collection).
+
+    :param table:
     """
-    Load json schema for the given catalog and connection
+    if isinstance(table.schema_.identifier, list):
+        identifiers = table.schema_.identifier.copy()
+        if table.temporal:
+            identifiers.remove(table.temporal.identifier)
+        if len(identifiers) != 1:
+            raise LoadSchemaException("Please set entity_id explicitly, because AMS Schema identifier is ambiguous")
+        return identifiers[0]
+    return table.schema_.identifier
+
+
+def load_schema(schema: Schema):
+    """Load JSON Schema for the given catalog and collection.
 
     :param schema:
     """
     table, dataset = AMSchemaRepository().get_schema(schema)
 
-    if isinstance(table.schema_.identifier, list):
-        if not schema.entity_id:
-            raise LoadSchemaException("Please set entity_id explicitly, because AMS Schema identifier is of type list")
+    if not schema.entity_id:
+        identifier = _get_entity_id_from_amschema(table)
 
     # Convert to GOBModel format
     return {
         "attributes": _to_gob(table, dataset),
-        "entity_id": schema.entity_id or table.schema_.identifier,
+        "entity_id": schema.entity_id or identifier,
+        "has_states": bool(table.temporal),
         "version": f"ams_{table.version}"
     }
 
 
 def _to_gob(table: Table, dataset: Dataset):
-    """
-    Transforms the given schema (spec) to a GOB model
+    """Transform the given table schema (spec) to a GOB collection model.
 
     :param table:
     :param dataset:

--- a/gobcore/model/schema.py
+++ b/gobcore/model/schema.py
@@ -31,15 +31,12 @@ def load_schema(schema: Schema):
     """
     table, dataset = AMSchemaRepository().get_schema(schema)
 
-    if not schema.entity_id:
-        identifier = _get_entity_id_from_amschema(table)
-
     # Convert to GOBModel format
     return {
-        "attributes": _to_gob(table, dataset),
-        "entity_id": schema.entity_id or identifier,
+        "version": f"ams_{table.version}",
+        "entity_id": schema.entity_id or _get_entity_id_from_amschema(table),
         "has_states": bool(table.temporal),
-        "version": f"ams_{table.version}"
+        "attributes": _to_gob(table, dataset)
     }
 
 

--- a/tests/gobcore/model/test_model.py
+++ b/tests/gobcore/model/test_model.py
@@ -90,6 +90,21 @@ class TestModel(TestCase):
         # Test non existing abbreviation
         self.assertEqual(None, self.model.get_reference_by_abbreviations('xxx', 'xxx'))
 
+    def test_amschema_entity_id(self):
+        """Amsterdam schema identifiers to collection model entity_id tests."""
+        brk2_meta = self.model["brk2"]["collections"]["meta"]
+        self.assertEqual(brk2_meta["entity_id"], "id")
+        # Temporal (volgnummer)
+        brk2_kot = self.model["brk2"]["collections"]["kadastraleobjecten"]
+        self.assertEqual(brk2_kot["entity_id"], "identificatie")
+
+    def test_amschema_temporal(self):
+        """Amsterdam schema temporal table to collection model has_states tests."""
+        brk2_sjt = self.model["brk2"]["collections"]["kadastralesubjecten"]
+        self.assertFalse(brk2_sjt["has_states"])
+        brk2_zrt = self.model["brk2"]["collections"]["zakelijkerechten"]
+        self.assertTrue(brk2_zrt["has_states"])
+
     def test_legacy_attributes(self):
         peilmerken = self.model['nap']['collections']['peilmerken']
         self.assertTrue('legacy_attributes' in peilmerken)

--- a/tests/gobcore/model/test_schema.py
+++ b/tests/gobcore/model/test_schema.py
@@ -139,6 +139,7 @@ class TestAMSSchema(unittest.TestCase):
                 }
             },
             'entity_id': 'identificatie',
+            'has_states': False,
             'version': 'ams_2.0.0'
         }
 


### PR DESCRIPTION
- Use AMS Schema for entity_id and has_states
- Set Dataset.crs to GOB default (EPSG:28992)