### PR TITLE
Use connection string instead of dsn for oracle datastore

### DIFF
--- a/gobcore/datastore/oracle.py
+++ b/gobcore/datastore/oracle.py
@@ -9,16 +9,17 @@ from tempfile import TemporaryDirectory
 from gobcore.datastore.sql import SqlDatastore
 from gobcore.exceptions import GOBException
 
+
 # Require encryption on TCP level.
-# If th encryption is enabled, the follwoing SQL gives output
+# Write this config to the sqlnet.ora file and pass it to oracledb.init_oracle_client
+# If the encryption is enabled, the following SQL gives output
 #
-#  select NETWORK_SERVICE_BANNER from v$session_connect_info where
-#    SID = sys_context('USERENV','SID')
-#    AND NETWORK_SERVICE_BANNER LIKE '%ncryption service adapter%'
+#  select NETWORK_SERVICE_BANNER
+#  from v$session_connect_info
+#  where SID = sys_context('USERENV','SID') AND NETWORK_SERVICE_BANNER LIKE '%ncryption service adapter%'
 #
 # Which will display something like:
-#   [{'network_service_banner':
-#     'AES256 Encryption service adapter for Linux: Version 19.0.0.0.0 - Production'}]
+#   [{'network_service_banner': 'AES256 Encryption service adapter for Linux: Version 19.0.0.0.0 - Production'}]
 ORACLE_CONFIG = """
 SQLNET.CRYPTO_CHECKSUM_CLIENT = required
 SQLNET.CRYPTO_CHECKSUM_TYPES_CLIENT = (SHA512)

--- a/gobcore/datastore/oracle.py
+++ b/gobcore/datastore/oracle.py
@@ -1,172 +1,125 @@
-from typing import List
+from pathlib import Path
 
-import re
+from typing import List, Iterator, Callable, Optional, Any
+
 import os
 import oracledb
-import tempfile
-import shutil
+from tempfile import TemporaryDirectory
 
-from sqlalchemy.engine.url import URL
 from gobcore.datastore.sql import SqlDatastore
 from gobcore.exceptions import GOBException
 
-ORACLE_DRIVER = 'oracle+cx_oracle'
-
-
-DSN_FAILOVER_TEMPLATE = """
-(DESCRIPTION=
-    (FAILOVER={failover})
-    (LOAD_BALANCE=off)
-    (CONNECT_TIMEOUT=3)
-    (RETRY_COUNT=3)
-    (ADDRESS_LIST={address_list})
-    (CONNECT_DATA=(SERVICE_NAME={database})))
-"""
-DSN_FAILOVER_ADDRESS_TEMPLATE = '(ADDRESS=(PROTOCOL=tcp)(HOST={host})(PORT={port}))'
-
+# Require encryption on TCP level.
+# If th encryption is enabled, the follwoing SQL gives output
+#
+#  select NETWORK_SERVICE_BANNER from v$session_connect_info where
+#    SID = sys_context('USERENV','SID')
+#    AND NETWORK_SERVICE_BANNER LIKE '%ncryption service adapter%'
+#
+# Which will display something like:
+#   [{'network_service_banner':
+#     'AES256 Encryption service adapter for Linux: Version 19.0.0.0.0 - Production'}]
 ORACLE_CONFIG = """
 SQLNET.CRYPTO_CHECKSUM_CLIENT = required
 SQLNET.CRYPTO_CHECKSUM_TYPES_CLIENT = (SHA512)
 SQLNET.ENCRYPTION_CLIENT = required
 SQLNET.ENCRYPTION_TYPES_CLIENT = (AES256)
 """
+os.environ["NLS_LANG"] = ".UTF8"
 
 
 class OracleDatastore(SqlDatastore):
 
+    _client_initialised = False
+
+    @classmethod
+    def _init_client(cls):
+        """
+        Initializes the Oracle client by creating a temporary directory and writing the ORACLE_CONFIG
+        to a sqlnet.ora file in that directory.
+        It then calls oracledb.init_oracle_client() to initialize the client.
+        """
+        if not cls._client_initialised:
+            with TemporaryDirectory() as tmpdir:
+                Path(tmpdir, "sqlnet.ora").write_text(ORACLE_CONFIG)
+                oracledb.init_oracle_client(config_dir=tmpdir)
+
+            cls._client_initialised = True
+
     def __init__(self, connection_config: dict, read_config: dict = None):
         super(OracleDatastore, self).__init__(connection_config, read_config)
+        self._init_client()
 
-        self.connection_config['drivername'] = ORACLE_DRIVER
-        self.connection_config['url'] = self.get_url()
-        self.oracle_config_dir = tempfile.mkdtemp()
-        # Reuire encryption on TCP level.
-        # If th encryption is enabled, the follwoing SQL gives output
-        #
-        #  select NETWORK_SERVICE_BANNER from v$session_connect_info where
-        #    SID = sys_context('USERENV','SID')
-        #    AND NETWORK_SERVICE_BANNER LIKE '%ncryption service adapter%'
-        #
-        # Which will display something like:
-        #   [{'network_service_banner':
-        #     'AES256 Encryption service adapter for Linux: Version 19.0.0.0.0 - Production'}]
-        #
-        oracle_config = os.path.join(self.oracle_config_dir, 'sqlnet.ora')
-        with open(oracle_config, 'w') as f:
-            f.write(ORACLE_CONFIG)
-        os.environ['TNS_ADMIN'] = self.oracle_config_dir
+    def connect(self) -> oracledb.Connection:
+        """Connect to the Oracle datasource using oracledb."""
+        config = self.connection_config
 
-        oracledb.init_oracle_client()
-        assert not oracledb.is_thin_mode(), "Oracle Thick mode is required"
-
-    def __del__(self):
-        shutil.rmtree(self.oracle_config_dir)
-
-    def get_url(self):
-        # Allow mutiple hosts speciefied, comma separated
-        items = {k: str(v).split(',')[0] if k in ('host', 'port') else v
-                 for k, v in self.connection_config.items() if k != 'name'}
-        url = URL.create(**items)
-
-        # The Oracle driver can accept a service name instead of a SID
-        service_name_pattern = re.compile(r"^\w+\.\w+\.\w+$")
-        if service_name_pattern.match(self.connection_config["database"]):
-            # Replace the SID by the service name
-            url = str(url).replace(self.connection_config["database"],
-                                   '?service_name=' + self.connection_config['database'])
-        return url
-
-    @staticmethod
-    def _get_dsn(host: str, port: str, database: str):
-        '''
-          Return dsn in Oracle easyconnect string or a description string.
-          The later if multiple hosts or ports are specified.
-        '''
-        def strech_list(a, b_len):
-            '''
-              Return list a streched to b_len filled with the last element of a
-            '''
-            return a + [a[-1]] * max(b_len - len(a), 0)
-
-        def filter_whitespace(text: str):
-            return ''.join(text.split())
-
-        hosts, ports = host.split(','), port.split(',')
-        ports = strech_list(ports, len(hosts))
-        hosts = strech_list(hosts, len(ports))
-        address_list = [DSN_FAILOVER_ADDRESS_TEMPLATE.format(host=h, port=p) for h, p in zip(hosts, ports)]
-
-        return filter_whitespace(
-            DSN_FAILOVER_TEMPLATE.format(
-                failover='off' if len(address_list) == 1 else 'on',
-                address_list=''.join(address_list),
-                database=database
-            )
-        )
-
-    def connect(self):
-        """Connect to the datasource
-
-        The oracledb library is used to connect to the data source for databases
-
-        :return: a connection to the given database
-        """
-        # Set the NLS_LANG variable to UTF-8 to get the correct encoding
-        os.environ["NLS_LANG"] = ".UTF8"
         try:
-            items = ('database', 'username', 'password', 'port', 'host')
-            database, username, password, port, host = [str(self.connection_config[k]) for k in items]
-            self.user = f"({username}@{database})"
-            dsn = self._get_dsn(host, port, database)
-            self.connection = oracledb.Connection(user=username, password=password, dsn=dsn)
+            self.user = f"({config['username']}@{config['database']})"
+            dsn = self._get_connection_string(retry_count=3, connection_timeout=3)
+            connection = oracledb.connect(dsn)
+            connection.outputtypehandler = self._output_type_handler
         except KeyError as e:
-            raise GOBException(f'Missing configuration for source {self.connection_config["name"]}. Error: {e}')
+            raise GOBException(f"Missing configuration for source '{config['name']}': {e}")
+        except oracledb.OperationalError as e:
+            raise GOBException(f"Database connection for source {config['name']} {self.user} failed: {e}")
 
-    def disconnect(self):
-        if self.connection:
-            self.connection.close()
-            self.connection = None
+        self.connection = connection
+        return connection
 
-    def _makedict(self, cursor):
-        """Convert query result to be a dictionary."""
-        cols = [d[0].lower() for d in cursor.description]
+    def query(self, query: str, **kwargs) -> Iterator[dict[str, Any]]:
+        """Return query result iterator from the database formatted as dictionary."""
+        with self.connection.cursor() as cur:
+            if "arraysize" in kwargs:
+                cur.arraysize = kwargs["arraysize"]
 
-        def createrow(*args):
-            return dict(zip(cols, args))
-
-        return createrow
-
-    def _output_type_handler(self, cursor, name, defaultType, size, precision, scale):
-        if defaultType == oracledb.CLOB:
-            return cursor.var(oracledb.LONG_STRING, arraysize=cursor.arraysize)
-
-    def query(self, query, **kwargs):
-        """
-        Reads from the database.
-
-        The oracledb library is used to connect to the data source for databases
-
-        :return: a list of data
-        """
-        FETCH_PER = kwargs.pop('arraysize', 100)  # Fetch contents in chunks, default chunk size = 100
-
-        cursor = self.connection.cursor()
-        cursor.arraysize = FETCH_PER
-        self.connection.outputtypehandler = self._output_type_handler
-        cursor.execute(query)
-        cursor.rowfactory = self._makedict(cursor)
-
-        for row in cursor:
-            yield row
+            result = cur.execute(query.rstrip(";"))
+            cur.rowfactory = self._dict_cursor(cur)  # execute query before setting rowfactory
+            yield from result
 
     def write_rows(self, table: str, rows: List[list]) -> None:
         raise NotImplementedError("Please implement write_rows for OracleDatastore")
 
     def execute(self, query: str) -> None:
-        raise NotImplementedError("Please implement execute for OracleDatastore")
+        """Executes a SQL statement on the database and commits the changes."""
+        with self.connection.cursor() as cur:
+            cur.execute(query)
+        self.connection.commit()
 
     def list_tables_for_schema(self, schema: str) -> List[str]:
         raise NotImplementedError("Please implement list_tables_for_schema for OracleDatastore")
 
     def rename_schema(self, schema: str, new_name: str) -> None:
         raise NotImplementedError("Please implement rename_schema for OracleDatastore")
+
+    def _get_connection_string(self, **kwargs) -> str:
+        """
+        Returns the connection string for the Oracle database according to 'Easy Connect' syntax.
+        see: https://docs.oracle.com/en/database/oracle/oracle-database/21/netag/configuring-naming-methods.html#GUID-8C85D289-6AF3-41BC-848B-BF39D32648BA
+        """
+        config = self.connection_config
+        hosts_list = config["host"].split(",")
+        hosts = ",".join(f"{host}:{config['port']}" for host in hosts_list)
+        service_name = config["database"]
+
+        params = {
+            "failover": "on" if len(hosts_list) > 1 else "off",
+            "load_balance": "on" if len(hosts_list) > 1 else "off"
+        } | kwargs
+        params = "&".join(f"{key}={value}".lower() for key, value in params.items())
+
+        connect_string = f"tcp://{hosts}/{service_name}?{params}"
+        return f"{config['username']}/{config['password']}@{connect_string}"
+
+    @staticmethod
+    def _dict_cursor(cursor: oracledb.Cursor) -> Callable[..., dict[str, Any]]:
+        """Convert query tuple a dictionary with column names as keys."""
+        cols = [d[0].lower() for d in cursor.description]
+        return lambda *args: dict(zip(cols, args))
+
+    @staticmethod
+    def _output_type_handler(
+            cursor: oracledb.Cursor, name: str, default_type, size, precision, scale
+    ) -> Optional[oracledb.Var]:
+        if default_type == oracledb.CLOB:
+            return cursor.var(oracledb.LONG_STRING, arraysize=cursor.arraysize)


### PR DESCRIPTION
- Only use temporary dir during initialisation of the thick client, __del__ not necessary anymore
- Use easy connect syntax for connection string
- Disconnect already implemented in SqlDatastore
- Simplified tests
- Remove (not used) sqlalchemy `get_url` logic