### PR TITLE
Use connection contextmanager to control transaction

### DIFF
--- a/gobcore/datastore/oracle.py
+++ b/gobcore/datastore/oracle.py
@@ -85,7 +85,7 @@ class OracleDatastore(SqlDatastore):
 
     def query(self, query: str, **kwargs) -> Iterator[dict[str, Any]]:
         """Return query result iterator from the database formatted as dictionary."""
-        with self.connection.cursor() as cur:
+        with self.connection, self.connection.cursor() as cur:
             if "arraysize" in kwargs:
                 cur.arraysize = kwargs["arraysize"]
 
@@ -98,9 +98,9 @@ class OracleDatastore(SqlDatastore):
 
     def execute(self, query: str) -> None:
         """Executes a SQL statement on the database and commits the changes."""
-        with self.connection.cursor() as cur:
+        with self.connection, self.connection.cursor() as cur:
             cur.execute(query)
-        self.connection.commit()
+            self.connection.commit()
 
     def list_tables_for_schema(self, schema: str) -> List[str]:
         raise NotImplementedError("Please implement list_tables_for_schema for OracleDatastore")

--- a/gobcore/datastore/oracle.py
+++ b/gobcore/datastore/oracle.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-
-from typing import List, Iterator, Callable, Optional, Any
+from collections.abc import Iterator, Callable
+from typing import Optional, Any
 
 import os
 import oracledb
@@ -93,7 +93,7 @@ class OracleDatastore(SqlDatastore):
             cur.rowfactory = self._dict_cursor(cur)  # execute query before setting rowfactory
             yield from result
 
-    def write_rows(self, table: str, rows: List[list]) -> None:
+    def write_rows(self, table: str, rows: list[list]) -> None:
         raise NotImplementedError("Please implement write_rows for OracleDatastore")
 
     def execute(self, query: str) -> None:
@@ -102,7 +102,7 @@ class OracleDatastore(SqlDatastore):
             cur.execute(query)
             self.connection.commit()
 
-    def list_tables_for_schema(self, schema: str) -> List[str]:
+    def list_tables_for_schema(self, schema: str) -> list[str]:
         raise NotImplementedError("Please implement list_tables_for_schema for OracleDatastore")
 
     def rename_schema(self, schema: str, new_name: str) -> None:

--- a/gobcore/datastore/postgres.py
+++ b/gobcore/datastore/postgres.py
@@ -1,4 +1,5 @@
-from typing import Iterator, Any
+from collections.abc import Iterator
+from typing import Any
 
 import psycopg2
 from psycopg2.extras import DictCursor, execute_values

--- a/gobcore/datastore/sql.py
+++ b/gobcore/datastore/sql.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import List
 
 from gobcore.datastore.datastore import Datastore
 
@@ -20,7 +19,7 @@ class SqlDatastore(Datastore, ABC):
             self.connection = None
 
     @abstractmethod
-    def write_rows(self, table: str, rows: List[list]) -> None:
+    def write_rows(self, table: str, rows: list[list]) -> None:
         pass
 
     @abstractmethod
@@ -28,7 +27,7 @@ class SqlDatastore(Datastore, ABC):
         pass
 
     @abstractmethod
-    def list_tables_for_schema(self, schema: str) -> List[str]:
+    def list_tables_for_schema(self, schema: str) -> list[str]:
         pass
 
     @abstractmethod
@@ -53,7 +52,7 @@ class SqlDatastore(Datastore, ABC):
         query = f"CREATE SCHEMA IF NOT EXISTS {schema}"
         self.execute(query)
 
-    def drop_table(self, table: str, cascade=True) -> None:
+    def drop_table(self, table: str, cascade: bool = True) -> None:
         """Drops table
 
         :param cascade:

--- a/gobcore/datastore/sql.py
+++ b/gobcore/datastore/sql.py
@@ -21,19 +21,19 @@ class SqlDatastore(Datastore, ABC):
 
     @abstractmethod
     def write_rows(self, table: str, rows: List[list]) -> None:
-        pass  # pragma: no cover
+        pass
 
     @abstractmethod
     def execute(self, query: str) -> None:
-        pass  # pragma: no cover
+        pass
 
     @abstractmethod
     def list_tables_for_schema(self, schema: str) -> List[str]:
-        pass  # pragma: no cover
+        pass
 
     @abstractmethod
     def rename_schema(self, schema: str, new_name: str) -> None:
-        pass  # pragma: no cover
+        pass
 
     def drop_schema(self, schema: str) -> None:
         """Drops schema with all its contents

--- a/gobcore/datastore/sqlserver.py
+++ b/gobcore/datastore/sqlserver.py
@@ -24,16 +24,10 @@ class SqlServerDatastore(SqlDatastore):
             f"PWD={self.connection_config['password']}"
         )
 
-        self.connection = pyodbc.connect(connstring, autocommit=True)
-
-    def disconnect(self):
-        if self.connection:
-            self.connection.close()
-            self.connection = None
+        self.connection = pyodbc.connect(connstring)
 
     def query(self, query, **kwargs):
-        cursor = self.connection.cursor()
-        with self.connection:
+        with self.connection, self.connection.cursor() as cursor:
             cursor.execute(query)
 
             for row in cursor.fetchall():

--- a/tests/gobcore/datastore/test_oracle.py
+++ b/tests/gobcore/datastore/test_oracle.py
@@ -90,6 +90,8 @@ class TestOracleDatastore(TestCase):
         query = "SELECT this FROM that WHERE this=that;"
         result = list(self.store.query(query, arraysize=5))
 
+        mock_conn.__enter__.assert_called_once()
+        mock_conn.__exit__.assert_called_with(None, None, None)
         assert 5 == mock_cursor.arraysize
         assert [{"id": 1}, {"id": 2}] == result
         mock_cursor.execute.assert_called_with(query[:-1])
@@ -102,6 +104,8 @@ class TestOracleDatastore(TestCase):
 
         self.store.execute("SELECT 1")
 
+        mock_conn.__enter__.assert_called_once()
+        mock_conn.__exit__.assert_called_with(None, None, None)
         mock_cursor.execute.assert_called_with("SELECT 1")
         mock_conn.commit.assert_called_once()
 

--- a/tests/gobcore/datastore/test_sql.py
+++ b/tests/gobcore/datastore/test_sql.py
@@ -10,7 +10,7 @@ class SqlDatastoreImpl(SqlDatastore):
     def connect(self):
         pass
 
-    def query(self, query):
+    def query(self, query, **kwargs):
         pass
 
     def write_rows(self, table: str, rows: List[list]) -> None:


### PR DESCRIPTION
In case of any exception this will rollback the current transaction. 
Don't depend on calling disconnect() on the datastore for this.