### PR TITLE
Don't close oracle connection after execute

### DIFF
--- a/gobcore/datastore/oracle.py
+++ b/gobcore/datastore/oracle.py
@@ -85,7 +85,7 @@ class OracleDatastore(SqlDatastore):
 
     def query(self, query: str, **kwargs) -> Iterator[dict[str, Any]]:
         """Return query result iterator from the database formatted as dictionary."""
-        with self.connection, self.connection.cursor() as cur:
+        with self.connection.cursor() as cur:
             if "arraysize" in kwargs:
                 cur.arraysize = kwargs["arraysize"]
 
@@ -98,9 +98,13 @@ class OracleDatastore(SqlDatastore):
 
     def execute(self, query: str) -> None:
         """Executes a SQL statement on the database and commits the changes."""
-        with self.connection, self.connection.cursor() as cur:
-            cur.execute(query)
+        try:
+            with self.connection.cursor() as cur:
+                cur.execute(query)
             self.connection.commit()
+        except oracledb.Error as e:
+            self.connection.rollback()
+            raise GOBException(f"Error executing query: {e}")
 
     def list_tables_for_schema(self, schema: str) -> list[str]:
         raise NotImplementedError("Please implement list_tables_for_schema for OracleDatastore")

--- a/tests/gobcore/datastore/test_oracle.py
+++ b/tests/gobcore/datastore/test_oracle.py
@@ -90,8 +90,6 @@ class TestOracleDatastore(TestCase):
         query = "SELECT this FROM that WHERE this=that;"
         result = list(self.store.query(query, arraysize=5))
 
-        mock_conn.__enter__.assert_called_once()
-        mock_conn.__exit__.assert_called_with(None, None, None)
         assert 5 == mock_cursor.arraysize
         assert [{"id": 1}, {"id": 2}] == result
         mock_cursor.execute.assert_called_with(query[:-1])
@@ -104,10 +102,13 @@ class TestOracleDatastore(TestCase):
 
         self.store.execute("SELECT 1")
 
-        mock_conn.__enter__.assert_called_once()
-        mock_conn.__exit__.assert_called_with(None, None, None)
         mock_cursor.execute.assert_called_with("SELECT 1")
         mock_conn.commit.assert_called_once()
+
+        mock_cursor.execute.side_effect = oracledb.Error("FATAL")
+        with self.assertRaisesRegex(GOBException, "FATAL"):
+            self.store.execute("SELECT 1")
+        mock_conn.rollback.assert_called_once()
 
     def test_not_implemented_methods(self):
         methods = [


### PR DESCRIPTION
The contextmanager also closes the connection on exit. Prepare re-uses this so keep it open.