### PR TITLE
Fix GOB-Core installs for regular (none editable) mode.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,36 @@
+[project]
+name = "gobcore"
+description = "GOB Core Components"
+keywords = ["GOB", "Core", "Components", "Amsterdam"]
+readme = "README.md"
+requires-python = ">=3.9, <3.10"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+]
+authors = [{name = "BenK devs"}]
+license = {text = 'MPL 2.0'}
+version = "2.20.2"
+
+[project.urls]
+Homepage = "https://github.com/Amsterdam/GOB-Core"
+Repository = "https://github.com/Amsterdam/GOB-Core"
+
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+license-files = ["LICENSE"]
+
+[tool.setuptools.packages.find]
+include = ["gobcore*"]
+
+[tool.setuptools.package-data]
+gobcore = ["**/*.json", "**/*.sql"]
+
 [tool.black]
 line-length = 120
 color = true

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,23 @@
+"""Setup script for building the GOB-Core distribution."""
+
 import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 def replace_env(line: str) -> str:
-    if '==' not in line:
+    """Honor environment variables (${LIBGDAL_VERSION}) in package versions."""
+    if "==" not in line:
         return line
 
-    package, version = line.split('==')
-    if version[:2] == '${' and version[-1] == '}':
+    package, version = line.split("==")
+    if version[:2] == "${" and version[-1] == "}":
         version = os.environ[version[2:-1]]
 
-    return f'{package}=={version}'
+    return f"{package}=={version}"
 
 
-with open('requirements.txt', mode='r') as reqs:
+with open("requirements.txt", mode="r", encoding="utf-8") as reqs:
     install_requires = [replace_env(req.strip()) for req in reqs.readlines()]
 
 
-setup(
-    name='gobcore',
-    version='0.1',
-    description='GOB Core Components',
-    url='https://github.com/Amsterdam/GOB-Core',
-    author='Datapunt',
-    author_email='',
-    license='MPL-2.0',
-    install_requires=install_requires,
-    packages=find_packages(exclude=['tests*'])
-)
+setup(install_requires=install_requires)


### PR DESCRIPTION
Set environment:
```bash
export LIBGDAL_VERSION=$(gdal-config --version)
```

Check package install:
```bash
pip install git+https://github.com/Amsterdam/GOB-Core.git@install_package
```

Check package files:
```bash
pip show -f gobcore
```

Check package metadata:
```bash
pip show -v gobcore
```

Build package wheel:
```bash
pip wheel --no-deps git+https://github.com/Amsterdam/GOB-Core.git@install_package
```