### PR TITLE
Add dependencies to dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ Homepage = "https://github.com/Amsterdam/GOB-Core"
 Repository = "https://github.com/Amsterdam/GOB-Core"
 
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42,<70", "wheel>=0.41,<0.42"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
 ]
 authors = [{name = "BenK devs"}]
 license = {text = 'MPL 2.0'}
-version = "2.25.1"
+# let setup,py handle dependencies, required for setuptools >= v69
+dynamic = ["dependencies"]
+version = "2.26.0"
+
 
 [project.urls]
 Homepage = "https://github.com/Amsterdam/GOB-Core"


### PR DESCRIPTION
https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#dynamic

We don't have a upper limit for setuptools version, which upgraded itself to v69.
This featured a deprecation which allowed 'dynamic' metadata without explicitely specifying it in pyproject.toml